### PR TITLE
Fix OpenXR projection warping and menu clipping

### DIFF
--- a/docs/vr-projection-fix/README.md
+++ b/docs/vr-projection-fix/README.md
@@ -1,0 +1,262 @@
+# OpenXR Projection, Menu, and Shader Crash Fixes
+
+This document describes the VR rendering corrections made while testing the
+v1.3 beta source on Meta Quest 3. It is intended to help future contributors
+understand why the changes exist, how the projection math works, and which
+parts must remain separate.
+
+## Contribution Credit
+
+This contribution was made by **J4nky**, using **ChatGPT Codex 5.6 Sol** as a
+collaborative development tool to diagnose the rendering problems and to
+understand how the OpenXR camera, per-eye frustums, and projection pipeline
+work. J4nky performed the headset testing and provided the visual observations
+that identified and verified the fixes.
+
+## Status
+
+Confirmed configurations:
+
+- Quest 2 standalone
+- Quest 3 standalone
+- Quest PCVR through the Meta OpenXR runtime
+- Quest PCVR through Virtual Desktop and SteamVR/OpenXR
+
+Confirmed behavior:
+
+- Physical head rotation no longer causes the world to stretch or skew near
+  the edges of the lenses.
+- In-game menus and HUD elements retain their correct vertical placement.
+- Entering the Carrington Institute menu no longer causes the native crash
+  encountered during development of the projection fix.
+
+Still requiring validation:
+
+- Headsets with strongly canted or unusually asymmetric displays
+
+The projection values are obtained dynamically from OpenXR. No Quest-specific
+FOV, lens centre, IPD, or aspect values are hard-coded, so the correction is
+designed to work on other OpenXR headsets.
+
+## Original Symptoms
+
+### World warping during physical head movement
+
+The view had a light fisheye-like stretch at the edges. It was most visible
+when the player physically looked left, right, up, or down. Turning with the
+controller while facing forward produced much less distortion.
+
+This distinction was important: it pointed to a mismatch between the
+projection used to render the scene and the projection that OpenXR used when
+presenting the submitted eye images.
+
+### Menus shifted and clipped at the top
+
+The first projection correction removed the world warping but moved 2D menu
+content upward. Some menu content was then clipped above its panel.
+
+### Crash entering the Carrington Institute menu
+
+After expanding the generated VR shader, the title screen rendered but the
+application crashed with `SIGSEGV` while entering Carrington. The menu used a
+larger shader variant than the title screen.
+
+## Projection Root Cause
+
+OpenXR supplies an `XrFovf` for each eye:
+
+- `angleLeft`
+- `angleRight`
+- `angleUp`
+- `angleDown`
+
+These angles normally describe an asymmetric frustum. The original renderer
+continued to use Perfect Dark's symmetric projection for the world. It passed
+some horizontal per-eye projection data to the multiview shader, but it did
+not fully reproduce the OpenXR projection:
+
+- The game projection aspect effectively became `1.0` instead of using the
+  optical frustum's aspect.
+- Vertical FOV was derived from angular span, which is only equivalent to the
+  correct tangent-space calculation for a symmetric frustum.
+- Horizontal frustum-centre data was used, but vertical frustum-centre data
+  was discarded.
+- The tangent half-FOV helper used eye 0 for both eyes.
+
+The result was a rendered image whose projection did not match the projection
+OpenXR expected. Runtime lens correction then made the mismatch visible as
+world stretching or swimming during physical head rotation.
+
+## Correct Projection Math
+
+For each eye, convert the OpenXR angles to tangent-space extents:
+
+```text
+tanLeft   = tan(angleLeft)
+tanRight  = tan(angleRight)
+tanUp     = tan(angleUp)
+tanDown   = tan(angleDown)
+
+tanHalfWidth  = (tanRight - tanLeft) / 2
+tanHalfHeight = (tanUp - tanDown) / 2
+```
+
+The game still needs one symmetric base projection, so the half-widths and
+half-heights are averaged across both eyes. The base values are then:
+
+```text
+verticalFov = 2 * atan(averageTanHalfHeight)
+aspect      = averageTanHalfWidth / averageTanHalfHeight
+```
+
+The asymmetric centre terms remain per-eye and come from the OpenXR
+column-major projection matrices:
+
+```text
+matrix[0] = horizontal scale
+matrix[8] = horizontal frustum centre
+matrix[9] = vertical frustum centre
+```
+
+The renderer sends four values per eye to the multiview shader:
+
+```text
+x = scaled eye/IPD translation
+y = horizontal frustum centre
+z = HUD parallax offset
+w = vertical frustum centre
+```
+
+For normal 3D world geometry, the shader applies both asymmetric centre terms:
+
+```glsl
+mvPos.x -= eyeOffset.x + (eyeOffset.y * mvPos.w);
+mvPos.y -= eyeOffset.w * mvPos.w;
+```
+
+## Why Menus Must Be Treated Separately
+
+Menus and HUD elements are authored in screen/clip space rather than being
+ordinary world geometry. Applying the optical vertical-centre correction to
+every vertex shifted the entire interface vertically.
+
+On the Quest 3 used for diagnosis, OpenXR reported a vertical centre term of
+approximately `-0.193`. Applying that globally moved screen-space interface
+geometry upward by roughly 19 percent of clip space, matching the observed
+clipping.
+
+The vertical correction must therefore remain inside the normal 3D-world
+branch:
+
+```glsl
+else if (uIsMenu == 0 && !vr_is_Menu_blur) {
+    mvPos.x -= eyeOffset.x + (eyeOffset.y * mvPos.w);
+    mvPos.y -= eyeOffset.w * mvPos.w;
+}
+```
+
+Do not move the Y correction above the menu/HUD conditionals. Menus, HUD,
+crosshairs, blur geometry, and the legal-title treatment retain their existing
+special positioning.
+
+## Carrington Crash Root Cause
+
+The OpenGL backend constructs shader variants in local character buffers using
+append functions without bounds checking. The VR shader prelude is already
+about 3.2 KiB, while the vertex shader buffer was only 4 KiB. Simpler title
+shaders fit, but more complex menu variants could overflow the buffer and
+corrupt the native stack.
+
+The vertex and fragment shader construction buffers were increased to 16 KiB.
+This fix only prevents memory corruption; it does not alter menu layout or
+projection behavior.
+
+Future work should replace the unchecked fixed-buffer construction with a
+bounded builder or dynamically sized string. The larger buffers are a safe
+practical correction, but they do not make the append functions intrinsically
+safe.
+
+## Files Changed
+
+| File | Responsibility |
+| --- | --- |
+| `port/vr/vr_openxr.cpp` | Derives base FOV/aspect from OpenXR tangent extents, keeps per-eye projection matrices, fixes the per-eye tangent lookup, and logs projection diagnostics. |
+| `port/vr/vr_openxr.h` | Exposes the runtime-derived `XrAspect`. |
+| `src/game/player.c` | Uses `XrAspect` for the game's world projection instead of the previous value that effectively collapsed to `1.0`. |
+| `port/fast3d/gfx_pc.cpp` | Sends horizontal and vertical projection-centre terms for both eyes to the rendering backend. |
+| `port/fast3d/gfx_rendering_api.h` | Expands the eye-offset rendering callback from six to eight values. |
+| `port/fast3d/gfx_opengl.cpp` | Stores four values per eye, uploads `vec4` uniforms, applies vertical asymmetry only to 3D world geometry, and enlarges generated-shader buffers. |
+
+## Quest 3 Diagnostic Values
+
+These are recorded examples, not constants to copy into the code:
+
+```text
+Eye 0 FOV radians: left=-0.942478 right=0.698132 up=0.767945 down=-0.959931
+Eye 1 FOV radians: left=-0.698132 right=0.942478 up=0.767945 down=-0.959931
+Game projection: vertical_fov=100.2439 aspect=0.925494
+```
+
+Approximate angular extents were:
+
+- Left eye: left -54 degrees, right 40 degrees, up 44 degrees, down -55 degrees
+- Right eye: left -40 degrees, right 54 degrees, up 44 degrees, down -55 degrees
+
+The left/right difference demonstrates horizontal asymmetry. The unequal
+up/down values demonstrate why the missing vertical centre term mattered.
+
+## Building and Testing Android
+
+From the `android` directory on Windows:
+
+```powershell
+.\gradlew.bat assembleDebug
+```
+
+The APK is produced at:
+
+```text
+android/app/build/outputs/apk/debug/app-debug.apk
+```
+
+Install it while preserving the existing debug app data:
+
+```powershell
+adb -s <device-serial> install -r android\app\build\outputs\apk\debug\app-debug.apk
+```
+
+Useful projection log messages include:
+
+```text
+OpenXR eye <n> FOV radians: ...
+OpenXR game projection: vertical_fov=... aspect=...
+OpenXR eye <n> projection: scale_x=... center_x=... scale_y=... center_y=...
+```
+
+## Regression Checklist
+
+For every headset/runtime combination:
+
+1. Physically rotate the headset left/right and up/down while looking at
+   straight architectural edges near the lens periphery. Confirm the world
+   does not stretch, skew, or swim.
+2. Repeat using controller snap/smooth turning to compare physical and
+   artificial rotation.
+3. Enter the Carrington Institute main menu and confirm there is no crash.
+4. Open several in-game menus, including the player-name keyboard and mission
+   completion panels. Confirm their top edges and text are not clipped.
+5. Check the HUD and both crosshairs in normal gameplay.
+6. Check the legal/title splash and fullscreen menu blur.
+7. Capture the projection log values and record the headset model and active
+   OpenXR runtime with the test result.
+
+## Important Maintenance Notes
+
+- Do not substitute swapchain texture aspect for optical-frustum aspect. They
+  are not guaranteed to be equivalent.
+- Do not calculate asymmetric FOV from angle span alone; use tangent extents.
+- Do not reuse eye 0 projection data for eye 1.
+- Do not apply the vertical optical-centre offset globally to menus and HUD.
+- Do not reduce the generated vertex shader buffer to 4 KiB.
+- Keep testing headset-specific behavior through reported OpenXR values rather
+  than adding hard-coded Quest 2, Quest 3, or SteamVR constants.

--- a/port/fast3d/gfx_opengl.cpp
+++ b/port/fast3d/gfx_opengl.cpp
@@ -31,7 +31,10 @@
 // GLOBAL STATE - OVR_multiview / Render Targets / others
 // ============================================================================
 bool use_multiview = false;
-float s_eye_offsets[6] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+// Per eye: IPD translation, horizontal frustum centre, HUD parallax,
+// vertical frustum centre.
+float s_eye_offsets[8] = { 0.0f, 0.0f, 0.0f, 0.0f,
+                           0.0f, 0.0f, 0.0f, 0.0f };
 extern float g_eyeTanHalfFov[2];
 extern "C" bool vr_dl_is_pause_or_menu;
 extern float vr_world_scale;
@@ -313,17 +316,19 @@ static bool gfx_opengl_is_multiview(void) {
 }
 
 
-static void gfx_opengl_set_eye_offsets(float left_ipd, float left_asym, float left_hud,
-                                       float right_ipd, float right_asym, float right_hud) {
+static void gfx_opengl_set_eye_offsets(float left_ipd, float left_asym_x, float left_hud, float left_asym_y,
+                                       float right_ipd, float right_asym_x, float right_hud, float right_asym_y) {
     // Left eye (gl_ViewID_OVR == 0)
-    s_eye_offsets[0] = left_ipd;   // vec3.x: 3D IPD
-    s_eye_offsets[1] = left_asym;  // vec3.y: Lens asymmetry
-    s_eye_offsets[2] = left_hud;   // vec3.z: 2D offset (HUD)
+    s_eye_offsets[0] = left_ipd;     // vec4.x: 3D IPD
+    s_eye_offsets[1] = left_asym_x;  // vec4.y: horizontal lens asymmetry
+    s_eye_offsets[2] = left_hud;     // vec4.z: 2D offset (HUD)
+    s_eye_offsets[3] = left_asym_y;  // vec4.w: vertical lens asymmetry
 
     // Right eye (gl_ViewID_OVR == 1)
-    s_eye_offsets[3] = right_ipd;  // vec3.x: 3D IPD
-    s_eye_offsets[4] = right_asym; // vec3.y: Lens asymmetry
-    s_eye_offsets[5] = right_hud;  // vec3.z: 2D offset (HUD)
+    s_eye_offsets[4] = right_ipd;
+    s_eye_offsets[5] = right_asym_x;
+    s_eye_offsets[6] = right_hud;
+    s_eye_offsets[7] = right_asym_y;
 
 }
 
@@ -471,10 +476,12 @@ static void gfx_opengl_set_uniforms(struct ShaderProgram* prg) {
     if (use_multiview) { // VR
 
         if (prg->eyeOffsetLeftLocation >= 0)
-            glUniform3f(prg->eyeOffsetLeftLocation, s_eye_offsets[0], s_eye_offsets[1], s_eye_offsets[2]);
+            glUniform4f(prg->eyeOffsetLeftLocation,
+                        s_eye_offsets[0], s_eye_offsets[1], s_eye_offsets[2], s_eye_offsets[3]);
 
         if (prg->eyeOffsetRightLocation >= 0)
-            glUniform3f(prg->eyeOffsetRightLocation, s_eye_offsets[3], s_eye_offsets[4], s_eye_offsets[5]);
+            glUniform4f(prg->eyeOffsetRightLocation,
+                        s_eye_offsets[4], s_eye_offsets[5], s_eye_offsets[6], s_eye_offsets[7]);
 
         if (prg->isMenuLocation >= 0)
             glUniform1i(prg->isMenuLocation, vr_dl_is_pause_or_menu ? 1 : 0);
@@ -632,6 +639,9 @@ static void append_formula(char* buf, size_t* len, uint8_t c[2][4], bool do_sing
 }
 
 
+// OpenXR supplies asymmetric projection centres.  The original renderer only
+// accounted for the horizontal centre, so carry the vertical centre in the
+// fourth eye-offset component and apply it to clip-space Y below.
 const char* vr_shader = R"(
 vec4 mvPos = aVtxPos;
 
@@ -648,7 +658,7 @@ bool vr_is_crosshair_left = (abs(mvPos.w - 1.0) == 7.0);
 bool vr_is_Menu_blur = (abs(mvPos.w - 1.0) == 8.0);
 
 
-vec3 eyeOffset = (gl_ViewID_OVR == 0u) ? uEyeOffsetLeft : uEyeOffsetRight;
+vec4 eyeOffset = (gl_ViewID_OVR == 0u) ? uEyeOffsetLeft : uEyeOffsetRight;
 
 // --------------------
 // MENU / HUD IN PAUSE MODE (uIsMenu == 1)
@@ -695,8 +705,11 @@ else if (uIsMenu == 0 && vr_is_crosshair_left) {
     mvPos.w += 2.0f; // distance correction for the left crosshair
 }
 else if (uIsMenu == 0 && !vr_is_Menu_blur) {
-    // "Normal" 3D world: IPD & asymmetry
+    // "Normal" 3D world: IPD and asymmetric OpenXR projection. Menus and HUD
+    // are already authored in screen space, so applying the optical Y centre
+    // to them would shift and clip the interface vertically.
     mvPos.x -= eyeOffset.x + (eyeOffset.y * mvPos.w);
+    mvPos.y -= eyeOffset.w * mvPos.w;
 }
 
 // --------------------
@@ -717,9 +730,11 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     struct CCFeatures cc_features = { 0 };
     gfx_cc_get_features(shader_id0, shader_id1, &cc_features);
 
-    //    char vs_buf[2048];
-    char vs_buf[4096]; // VR
-    char fs_buf[8192];
+    // Shader variants used by menus can be substantially larger than gameplay
+    // variants.  The VR prelude alone is over 3 KiB, so the former 4 KiB vertex
+    // buffer could overflow while entering a menu and corrupt the native stack.
+    char vs_buf[16384];
+    char fs_buf[16384];
     size_t vs_len = 0;
     size_t fs_len = 0;
     size_t num_floats = 4;
@@ -738,8 +753,8 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
 
         // --- New Menu uniforms ---
         append_line(vs_buf, &vs_len, "uniform int uIsMenu;");
-        append_line(vs_buf, &vs_len, "uniform vec3 uEyeOffsetLeft;");
-        append_line(vs_buf, &vs_len, "uniform vec3 uEyeOffsetRight;");
+        append_line(vs_buf, &vs_len, "uniform vec4 uEyeOffsetLeft;");
+        append_line(vs_buf, &vs_len, "uniform vec4 uEyeOffsetRight;");
         append_line(vs_buf, &vs_len, "uniform float uWorldScale;");
         append_line(vs_buf, &vs_len, "uniform float uCrosshairParallaxLoc;");
         append_line(vs_buf, &vs_len, "uniform float uCrosshairParallaxLeftLoc;");

--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -2814,13 +2814,15 @@ extern "C" void gfx_run(Gfx* commands) {
                16 * sizeof(float));
 
 
-        float offsets[6] = {
-                tx0 * s_vr_proj_col_major[0], vr_get_eye_proj_mtx(0)[8], tx_HUD0 * vr_get_eye_proj_mtx(0)[0],
-                tx1 * s_vr_proj_col_major[0], vr_get_eye_proj_mtx(1)[8], tx_HUD1 * vr_get_eye_proj_mtx(1)[0]
+        float offsets[8] = {
+                tx0 * vr_get_eye_proj_mtx(0)[0], vr_get_eye_proj_mtx(0)[8],
+                tx_HUD0 * vr_get_eye_proj_mtx(0)[0], vr_get_eye_proj_mtx(0)[9],
+                tx1 * vr_get_eye_proj_mtx(1)[0], vr_get_eye_proj_mtx(1)[8],
+                tx_HUD1 * vr_get_eye_proj_mtx(1)[0], vr_get_eye_proj_mtx(1)[9]
         };
 
-        gfx_rapi->set_eye_offsets(offsets[0], offsets[1], offsets[2],
-                                  offsets[3], offsets[4], offsets[5]);
+        gfx_rapi->set_eye_offsets(offsets[0], offsets[1], offsets[2], offsets[3],
+                                  offsets[4], offsets[5], offsets[6], offsets[7]);
 
 
         // 1) Acquire + attach swapchain to g_multiviewFBO

--- a/port/fast3d/gfx_rendering_api.h
+++ b/port/fast3d/gfx_rendering_api.h
@@ -54,7 +54,8 @@ struct GfxRenderingAPI {
     enum FilteringMode (*get_texture_filter)(void);
 
     // VR
-    void (*set_eye_offsets)(float lx, float lfrustum, float lhud, float rx, float rfrustum, float rhud);
+    void (*set_eye_offsets)(float lx, float lfrustum_x, float lhud, float lfrustum_y,
+                            float rx, float rfrustum_x, float rhud, float rfrustum_y);
     bool (*is_multiview)(void);
     void (*mirror_to_desktop)(uint32_t src_w, uint32_t src_h, uint32_t dst_w, uint32_t dst_h);
 

--- a/port/vr/vr_openxr.cpp
+++ b/port/vr/vr_openxr.cpp
@@ -124,8 +124,9 @@ extern SDL_GLContext ctx;
 
 static float g_eyeProjMtx[2][16] = {};
 static float g_eyeViewMtx[2][16] = {};
-extern float s_eye_offsets[6];
+extern float s_eye_offsets[8];
 float XrFov = 0.0f;
+float XrAspect = 1.0f;
 float g_eyeTanHalfFov[2];
 float ipd_meters = 0.0f;;
 float VrStereoCrosshair = 0.70f;
@@ -503,6 +504,7 @@ extern "C" bool vr_configure_resolution() {
 
     // --- Calculate the actual HMD aspect ratio ---
     double aspectRatio = (double)VrRealRecommendedW / (double)VrRealRecommendedH;
+    XrAspect = (float)aspectRatio;
     LOGI("HMD aspect ratio: %.4f", aspectRatio);
 
     // --- Fixed width enforced, height derived from aspect ratio ---
@@ -1354,7 +1356,7 @@ static VrEyeFovTan vr_get_eye_fov_tan(int eye) {
     return out;
 }
 
-extern float s_eye_offsets[6];
+extern float s_eye_offsets[8];
 
 // -----------------------------------------------------------------------
 // STEREO: Asymmetric projection from XrFovf angles
@@ -1481,14 +1483,56 @@ extern "C" bool vr_begin_frame_and_update_poses()
         return false;
     }
 
+    // Build the symmetric projection used by the original game from the
+    // average OpenXR tangent extents.  Using the angular span directly is
+    // only correct for a perfectly symmetric frustum, and using the render
+    // target dimensions is not guaranteed to match the optical frustum.
+    // The per-eye centre offsets are applied later by the multiview shader.
+    float tanHalfWidthSum = 0.0f;
+    float tanHalfHeightSum = 0.0f;
+
+    for (int eye = 0; eye < 2; eye++) {
+        const XrFovf& fov = g_frameViews[eye].fov;
+        tanHalfWidthSum += (std::tanf(fov.angleRight) - std::tanf(fov.angleLeft)) * 0.5f;
+        tanHalfHeightSum += (std::tanf(fov.angleUp) - std::tanf(fov.angleDown)) * 0.5f;
+    }
+
+    const float tanHalfWidth = tanHalfWidthSum * 0.5f;
+    const float tanHalfHeight = tanHalfHeightSum * 0.5f;
+
+    if (tanHalfWidth > 0.001f && tanHalfHeight > 0.001f) {
+        XrFov = 2.0f * std::atanf(tanHalfHeight) * (180.0f / 3.14159265f);
+        XrAspect = tanHalfWidth / tanHalfHeight;
+    }
+
+    static bool projectionLogged = false;
+    if (!projectionLogged) {
+        for (int eye = 0; eye < 2; eye++) {
+            const XrFovf& fov = g_frameViews[eye].fov;
+            LOGI("OpenXR eye %d FOV radians: left=%.6f right=%.6f up=%.6f down=%.6f",
+                 eye, fov.angleLeft, fov.angleRight, fov.angleUp, fov.angleDown);
+        }
+        LOGI("OpenXR game projection: vertical_fov=%.4f aspect=%.6f",
+             XrFov, XrAspect);
+        for (int eye = 0; eye < 2; eye++) {
+            const XrFovf& fov = g_frameViews[eye].fov;
+            const float tanLeft = std::tanf(fov.angleLeft);
+            const float tanRight = std::tanf(fov.angleRight);
+            const float tanUp = std::tanf(fov.angleUp);
+            const float tanDown = std::tanf(fov.angleDown);
+            LOGI("OpenXR eye %d projection: scale_x=%.6f center_x=%.6f scale_y=%.6f center_y=%.6f",
+                 eye,
+                 2.0f / (tanRight - tanLeft),
+                 (tanRight + tanLeft) / (tanRight - tanLeft),
+                 2.0f / (tanUp - tanDown),
+                 (tanUp + tanDown) / (tanUp - tanDown));
+        }
+        projectionLogged = true;
+    }
+
     for (int eye = 0; eye < 2; eye++) {
         const XrFovf&  fov  = g_frameViews[eye].fov;
         const XrPosef& pose = g_frameViews[eye].pose;
-        // GET Fov
-        float vert = fov.angleUp - fov.angleDown;
-        XrFov =  vert * (180.0f / 3.14159265f);
-        XrFov = roundf(XrFov * 10.0f) / 10.0f;
-        //---
 
         float projMtx[16], viewMtx[16];
 
@@ -1506,7 +1550,7 @@ extern "C" bool vr_begin_frame_and_update_poses()
         std::memcpy(g_eyeProjMtx[eye], projMtx, 16 * sizeof(float));
         std::memcpy(g_eyeViewMtx[eye], viewMtx, 16 * sizeof(float));
 
-        VrEyeFovTan fovTan = vr_get_eye_fov_tan(0);
+        VrEyeFovTan fovTan = vr_get_eye_fov_tan(eye);
         float tanFovHalf = fovTan.tanHalfWidth;
 
         g_eyeTanHalfFov[eye] = tanFovHalf;

--- a/port/vr/vr_openxr.h
+++ b/port/vr/vr_openxr.h
@@ -52,6 +52,7 @@ int shaders_build_xr_projection(
 extern XrVector3f gHeadPos;
 extern XrQuaternionf vr_HMD_rot_Q;
 extern XrQuaternionf gRawHeadQ;
+extern float XrAspect;
 
 extern float gCtrlPos[2][3];
 extern float gCtrlQuat[2][4];

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -114,6 +114,7 @@ extern void vr_player_rot();
 static s16 g_PrevAnimNumForContinuity = -1;
 static f32 g_RefHMDQuat[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
 extern float XrFov;
+extern float XrAspect;
 float VrSetWorldScale = 1.0f;
 //---
 
@@ -3374,6 +3375,12 @@ f32 player0f0bd358(void)
 #ifdef PLATFORM_N64
     return result;
 #else
+    // OpenXR's optical frustum, rather than the swapchain dimensions, defines
+    // the projection aspect. The previous expression cancelled the render
+    // target ratio and forced this value to exactly 1.0 on every headset.
+    if (XrAspect > 0.01f) {
+        return XrAspect;
+    }
     return result * (videoGetAspect() / ((f32)VrSmallW / (f32)VrSmallH));
 #endif
 }


### PR DESCRIPTION
Used codex to identify possible issues, and solve math to eliminate the xr view warping when turning head in vr.