### PR TITLE
Extending StereoCrosshair range to acommodate PSVR2

### DIFF
--- a/port/vr/vr_settings.h
+++ b/port/vr/vr_settings.h
@@ -7,7 +7,7 @@ extern int g_ExtMenuPlayer;
 extern float XrFov;
 extern float VrStereoCrosshair;
 #define HUD_STEREO_DEPTH_MIN 0.0f
-#define HUD_STEREO_DEPTH_MAX 2.0f
+#define HUD_STEREO_DEPTH_MAX 4.0f
 extern bool VrSeatedMode;
 extern bool VrMotionThrowing;
 extern bool VrWeaponRecoil;


### PR DESCRIPTION
Increasing range for `StereoCrosshair` adjustment to 4.00 - PSVR2 needs a value of 2.50 to get lights / UI / crosshairs to properly align.

Tested on SteamVR with PSVR2