### PR TITLE
VR: floor-referenced height, and let the head leave the body

### DIFF
--- a/port/vr/vr_openxr.cpp
+++ b/port/vr/vr_openxr.cpp
@@ -259,7 +259,28 @@ bool orientationValid = false;
 
 XrQuaternionf gRawHeadQ = { 0, 0, 0, 1 };
 float g_yawOffsetDegrees = 0.0f;
-float gStandingHeadHeight = 0.0f;
+
+// ============================================================
+// FLOOR-REFERENCED HEAD HEIGHT
+// ============================================================
+// LOCAL_FLOOR/STAGE put the origin on the physical floor, so the runtime's Y is
+// already the true head height and nothing has to be calibrated or remembered.
+// A plain LOCAL space puts the origin wherever the head was when the space was
+// created, so there we calibrate once per level: the median head Y over ~1 s is
+// taken to be a standing pose. Median, not maximum -- a running maximum latches
+// onto a physical jump and never comes back down, which is what used to leave
+// the player permanently shorter for the rest of the session.
+bool  gVrFloorRelativeSpace = false;
+float gVrHeadHeightCm       = VR_NOMINAL_HEAD_HEIGHT_CM;
+
+extern "C" float VrPlayerHeight;   // your standing height, cm (bondwalk.c)
+
+#define VR_HEIGHT_CALIB_SAMPLES 90   // ~1 s of frames
+
+static float sHeightCalibSamples[VR_HEIGHT_CALIB_SAMPLES];
+static int   sHeightCalibCount  = 0;
+static bool  sHeightCalibDone   = false;
+static float sHeightCalibOffset = VR_NOMINAL_HEAD_HEIGHT_CM;
 
 // ============================================================
 // SMOOTHING HMD — When zoom is enabled
@@ -788,6 +809,11 @@ static bool vr_create_play_space()
         LOGI("Play space = LOCAL");
     }
 
+    // Only the first two report Y relative to the physical floor; LOCAL needs
+    // the one-shot height calibration instead.
+    gVrFloorRelativeSpace = (gPlaySpaceType != XR_REFERENCE_SPACE_TYPE_LOCAL);
+    vr_recalibrate_head_height();
+
     XrReferenceSpaceCreateInfo spaceInfo{ XR_TYPE_REFERENCE_SPACE_CREATE_INFO };
     spaceInfo.referenceSpaceType            = gPlaySpaceType;
     spaceInfo.poseInReferenceSpace.orientation = { 0, 0, 0, 1 };
@@ -1237,6 +1263,43 @@ static XrQuaternionf SlerpQuaternions(XrQuaternionf a, XrQuaternionf b, float t)
     return {out[1], out[2], out[3], out[0]};    // → {x,y,z,w}
 }
 
+// Turn the runtime's head Y into a height above the physical floor, in cm.
+static void vr_update_head_height()
+{
+    if (gVrFloorRelativeSpace) {
+        gVrHeadHeightCm = gHeadPos.y;
+        return;
+    }
+
+    if (!sHeightCalibDone) {
+        sHeightCalibSamples[sHeightCalibCount++] = gHeadPos.y;
+
+        if (sHeightCalibCount >= VR_HEIGHT_CALIB_SAMPLES) {
+            std::sort(sHeightCalibSamples, sHeightCalibSamples + VR_HEIGHT_CALIB_SAMPLES);
+
+            float median = sHeightCalibSamples[VR_HEIGHT_CALIB_SAMPLES / 2];
+            sHeightCalibOffset = VrPlayerHeight - median;
+            sHeightCalibDone   = true;
+
+            LOGI("Head height calibrated (LOCAL space): median %.1f cm, offset %.1f cm",
+                 median, sHeightCalibOffset);
+        }
+    }
+
+    gVrHeadHeightCm = gHeadPos.y + sHeightCalibOffset;
+}
+
+// Start a fresh calibration. No-op under a floor-relative space, where the
+// runtime already gives us absolute height.
+extern "C" void vr_recalibrate_head_height(void)
+{
+    sHeightCalibCount  = 0;
+    sHeightCalibDone   = false;
+    // Until the median lands, assume the head is at standing height, which is
+    // where a LOCAL space puts its own origin anyway.
+    sHeightCalibOffset = VrPlayerHeight;
+}
+
 static void vr_update_head_tracking(XrTime predictedDisplayTime)
 {
     if (!g_vrState.sessionRunning || g_vrState.session == XR_NULL_HANDLE) return;
@@ -1299,10 +1362,7 @@ static void vr_update_head_tracking(XrTime predictedDisplayTime)
             vr_HMD_rot_Q         = rawQ;
         }
 
-        if (gHeadPos.y > gStandingHeadHeight) {
-            gStandingHeadHeight = gHeadPos.y;
-        }
-
+        vr_update_head_height();
     }
 }
 

--- a/port/vr/vr_openxr.h
+++ b/port/vr/vr_openxr.h
@@ -58,7 +58,17 @@ extern float gCtrlPos[2][3];
 extern float gCtrlQuat[2][4];
 extern float gCtrlQuatRaw[2][4];
 
-extern float gStandingHeadHeight;
+// A plausible standing head (HMD) height in centimetres, used only until real
+// tracking arrives. Everything that cares about the player's actual height uses
+// the VrPlayerHeight setting.
+#define VR_NOMINAL_HEAD_HEIGHT_CM 160.0f
+
+// Head height above the physical floor, in centimetres. Under a floor-relative
+// reference space this is exactly what the runtime reports; under LOCAL it is
+// the reported Y plus a one-shot calibration offset.
+extern float gVrHeadHeightCm;
+extern bool gVrFloorRelativeSpace;
+
 extern bool vr_init_done;
 extern float vr_world_scale;
 
@@ -89,3 +99,15 @@ extern void gfx_vr_hud_capture_end_R(void);
 #define VR_HUD_CAPTURE_END_H 0x56570001
 extern void gfx_vr_hud_capture_begin_H(void);
 extern void gfx_vr_hud_capture_end_H(void);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Restart the LOCAL-space height calibration (called at level start).
+void vr_recalibrate_head_height(void);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/port/vr/vr_settings.cpp
+++ b/port/vr/vr_settings.cpp
@@ -24,6 +24,13 @@ extern "C" void vrSettingsSave(void)
     fprintf(f, "StickClickToCrouch=%d\n", VrStickClickToCrouch ? 1 : 0);
     fprintf(f, "UseSnapTurn=%d\n", VrUseSnapTurn ? 1 : 0);
     fprintf(f, "TwoHandedAiming=%d\n", VrTwoHandAim ? 1 : 0);
+    fprintf(f, "; Your standing EYE height in cm -- where your eyes are off the floor, which is\n");
+    fprintf(f, "; what the headset reports, roughly 13 cm below the top of your head. Set it from\n");
+    fprintf(f, "; the live reading beside the menu slider rather than from your stature.\n");
+    fprintf(f, "PlayerHeight=%.1f\n", VrPlayerHeight);
+    fprintf(f, "; 1 = stand at the height of the character you are playing instead of your own,\n");
+    fprintf(f, "; so Elvis is short and Mr Blonde towers. 0 = you are your own height throughout.\n");
+    fprintf(f, "MatchCharacterHeight=%d\n", VrMatchCharacterHeight ? 1 : 0);
 
     // --- VR hand placement (no menu UI; edit here) --------------------------------------------
     fprintf(f, "\n");
@@ -74,6 +81,7 @@ extern "C" void vrSettingsLoad(void)
             else if (strcmp(key, "StickClickToCrouch") == 0) VrStickClickToCrouch = (ival != 0);
             else if (strcmp(key, "UseSnapTurn") == 0) VrUseSnapTurn = (ival != 0);
             else if (strcmp(key, "TwoHandedAiming") == 0) VrTwoHandAim = (ival != 0);
+            else if (strcmp(key, "MatchCharacterHeight") == 0) VrMatchCharacterHeight = (ival != 0);
             else if (strcmp(key, "FistClench") == 0) VrFistClench = ival;
         }
 
@@ -94,7 +102,11 @@ extern "C" void vrSettingsLoad(void)
                 if (fval > WORLDSCALE_MAX) fval = WORLDSCALE_MAX;
                 VrSetWorldScale = fval;
             }
-
+            else if (strcmp(key, "PlayerHeight") == 0) {
+                if (fval < PLAYERHEIGHT_MIN) fval = PLAYERHEIGHT_MIN;
+                if (fval > PLAYERHEIGHT_MAX) fval = PLAYERHEIGHT_MAX;
+                VrPlayerHeight = fval;
+            }
             else if (strcmp(key, "ArmElbowTuck") == 0) VrArmElbowTuck = fval;
             else if (strcmp(key, "ArmBodyFollow") == 0) VrArmBodyFollow = fval;
             else if (strcmp(key, "GunOffX") == 0) VrGunOffX = fval;

--- a/port/vr/vr_settings.h
+++ b/port/vr/vr_settings.h
@@ -14,6 +14,20 @@ extern bool VrWeaponRecoil;
 #define WORLDSCALE_MIN    0.50f
 #define WORLDSCALE_MAX    1.50f
 extern float VrSetWorldScale;
+
+// Your standing EYE height in cm -- where your eyes are off the floor, roughly
+// 13 cm below the top of your head, not your stature. That is what the headset
+// reports and what the game's own vv_eyeheight means. It is the reference
+// physical crouching is measured against, and in character-height mode it maps
+// your stand onto the character's stand.
+#define PLAYERHEIGHT_MIN  130.0f
+#define PLAYERHEIGHT_MAX  200.0f
+extern float VrPlayerHeight;
+
+// false: your real height carries into the game -- your eyes sit where your own
+// eyes are whatever body you are wearing. true: you take the height of the
+// character you are playing, so Elvis is short and Mr Blonde towers.
+extern bool VrMatchCharacterHeight;
 extern int VrUseSnapTurn;
 extern bool VrTwoHandAim;       // two-handed weapons aim along the line between both controllers
 extern int VrStickClickToCrouch;

--- a/src/game/bondhead.c
+++ b/src/game/bondhead.c
@@ -214,10 +214,12 @@ void bheadUpdate(f32 arg0, f32 arg1)
             VrMaxHeight.y = (g_Vars.currentplayer->bondheadmatrices[0].m[3][1] -
                              g_Vars.currentplayer->standheight) *
                             g_Vars.currentplayer->headamplitude + g_Vars.currentplayer->standheight;
-            if (gHeadPos.y > VrMaxHeight.y) {
+            // Ceiling on the game body's head bone only -- it no longer feeds
+            // any height reference, so it cannot shrink the player.
+            if (gVrHeadHeightCm > VrMaxHeight.y) {
                 headpos.y = VrMaxHeight.y;
             } else {
-                headpos.y = gHeadPos.y;
+                headpos.y = gVrHeadHeightCm;
             }
         }
         else{
@@ -268,10 +270,10 @@ void bheadUpdate(f32 arg0, f32 arg1)
             struct coord VrMaxHeight = {0, 0, 0};
             VrMaxHeight.y = g_Vars.currentplayer->standheight;
 
-            if (gHeadPos.y > VrMaxHeight.y) {
+            if (gVrHeadHeightCm > VrMaxHeight.y) {
                 headpos.y = VrMaxHeight.y;
             } else {
-                headpos.y = gHeadPos.y;
+                headpos.y = gVrHeadHeightCm;
             }
         }
         else

--- a/src/game/bondmove.c
+++ b/src/game/bondmove.c
@@ -61,6 +61,7 @@ extern XrQuaternionf vr_joy_rot_Q;
 extern void vr_rotate_vector_by_quaternion(struct coord* v, const XrQuaternionf* q);
 static bool Prev_VR_BUTTON_X = false;
 extern VrEyeheightMode sVrEyeheightMode;
+extern float VrPlayerHeight;
 
 static bool sPrevGripState = false;
 bool g_DisableGrabViaB = true;
@@ -2563,11 +2564,14 @@ void bmoveTick(bool allowc1x, bool allowc1y, bool allowc1buttons, bool ignorec2)
 
     bmoveProcessInput(allowc1x, allowc1y, allowc1buttons, ignorec2);
 
-    // VR
+    // VR: duck/squat from how far your head is below your own standing height,
+    // measured against the physical floor. The reference is a setting, not a
+    // running maximum, so a physical jump can no longer raise it and leave you
+    // spuriously ducking afterwards.
     if(!VrSeatedMode){
-        if (gHeadPos.y < gStandingHeadHeight / 1.6f || sVrEyeheightMode == VR_EYEHEIGHT_SQUAT) {
+        if (gVrHeadHeightCm < VrPlayerHeight / 1.6f || sVrEyeheightMode == VR_EYEHEIGHT_SQUAT) {
             g_Vars.currentplayer->crouchpos = CROUCHPOS_SQUAT;
-        } else if (gHeadPos.y < gStandingHeadHeight / 1.3f  || sVrEyeheightMode == VR_EYEHEIGHT_DUCK) {
+        } else if (gVrHeadHeightCm < VrPlayerHeight / 1.3f  || sVrEyeheightMode == VR_EYEHEIGHT_DUCK) {
             g_Vars.currentplayer->crouchpos = CROUCHPOS_DUCK;
         } else {
             g_Vars.currentplayer->crouchpos = CROUCHPOS_STAND;

--- a/src/game/bondwalk.c
+++ b/src/game/bondwalk.c
@@ -55,7 +55,18 @@ float VrYawRot = 0.0f;
 
 extern bool vr_is_duel;
 extern float vr_player_angle;
+extern float VrSetWorldScale;
 static f32 sVrEyeheightClamped = 150.0f; // default for starting game
+
+// VR height settings. See vr_settings.h for what they mean; the menu writes
+// them and pd-vr.ini persists them. The default is an average adult's standing
+// eye height, which is a little under average stature.
+float VrPlayerHeight = 160.0f;
+bool VrMatchCharacterHeight = false;
+
+// Highest head height we will believe, in cm. Only there to swallow tracking
+// spikes; a real head never gets near it.
+#define VR_MAX_HEAD_CM 250.0f
 
 extern void vr_align_with_game_angle(float target_game_angle);
 static bool vr_hoverbike_can_mount = false;
@@ -137,98 +148,314 @@ void joy_for_vr(void) {
 
 static struct coord lastVRHeadPos = { 0.0f, 0.0f, 0.0f };
 
-void vr_player_pos(void) {
+// --- Roomscale: the head is allowed to leave the body ------------------------
+//
+// prop->pos is the BODY: the collision cylinder, what the AI shoots at, what
+// owns the rooms. The camera is the HEAD. Physically leaning moves only the
+// head; the body is dragged after it only once you have leaned far enough that
+// you are plainly walking rather than leaning, and it is that drag -- never the
+// lean -- that gets collision-tested against the body cylinder. This is what
+// lets you put your head over a balcony rail: the rail stops the body, which
+// was not going anywhere, and your head goes over it.
+//
+// Two offsets, because they are different questions. The PHYSICAL one is where
+// your head actually is and never refuses anything -- if it did, motion spent
+// pushing into a wall would be lost, and stepping back out would leave you
+// permanently displaced from your own body. The SHOWN one is where the camera
+// is allowed to be, the physical one clamped against solid geometry. Press into
+// a wall and they diverge; step back and they converge again on their own.
+//
+// Both kept in PLAY space (the headset's own frame) so that turning, stick or
+// snap, rotates them along with the world for free. Everything else wants game
+// space, which is a rotation away and recomputed every frame.
+static struct coord sVrHeadOffsetPlay = { 0.0f, 0.0f, 0.0f };   // physical
+static struct coord sVrShownOffsetPlay = { 0.0f, 0.0f, 0.0f };  // clamped
+static struct coord sVrHeadOffset = { 0.0f, 0.0f, 0.0f };       // clamped, game space
 
-    if(g_Vars.currentplayer->isdead == false
-       && g_Vars.tickmode == TICKMODE_NORMAL
-       && !vr_is_duel
-            ) {
+// How far the two have diverged, i.e. how far into something solid your real
+// head has gone. Drives the comfort fade.
+static f32 sVrHeadClipDist = 0.0f;
 
-        // Variables to store the new position
-        struct coord newPos;
-        struct coord delta;
-        RoomNum rooms[8];
-        f32 radius, ymax, ymin;
-        s32 collisionResult;
-        s32 types;
+// The body chases the head every tick -- roomscale walking is the body walking,
+// and it should be under you whenever it can be. Distance between the two opens
+// up only where the body physically cannot follow (a rail across its waist, a
+// wall at its shoulder) and closes again the moment the way is clear.
+//
+// Capped per tick so that catching up after a long lean stays a series of small
+// collision-tested steps rather than one long jump, which could skip through
+// thin geometry: cdExamCylMove02 only tests the destination. The cap is
+// invisible in play -- the camera is body + offset, so moving the body and
+// shrinking the offset by the same vector leaves the view exactly where it was.
+#define VR_BODY_CATCHUP_MAX 10.0f
 
+// How far your head gets past what the game will follow before the view is
+// fully black. This is comfort feedback, not occlusion: the probe has already
+// stopped the view at the wall, and this says so rather than letting you
+// wonder why the world stopped moving with you.
+#define VR_HEAD_FADE_START 2.0f
+#define VR_HEAD_FADE_FULL  10.0f
 
-        // Calculate the DISPLACEMENT (delta) from the previous frame
-        float deltaX = gHeadPos.x - lastVRHeadPos.x;
-        float deltaY = gHeadPos.y - lastVRHeadPos.y;
-        float deltaZ = gHeadPos.z - lastVRHeadPos.z;
+// The probe that keeps your head out of solid geometry. A head, not a body: it
+// is a short slab at eye level, so a waist-high rail passes underneath it and
+// stops blocking the view, which is the entire point.
+#define VR_HEAD_PROBE_RADIUS 12.0f
+#define VR_HEAD_PROBE_YMAX   10.0f
+#define VR_HEAD_PROBE_YMIN  -10.0f
 
-        // Transform the VR movement according to the joystick rotation
-        delta.x = deltaX;
-        delta.y = deltaY;
-        delta.z = deltaZ;
-        vr_rotate_vector_by_quaternion(&delta, &vr_joy_rot_Q);
+// No single frame can legitimately hold this much head motion (25 cm at 90 Hz
+// is 22 m/s). Anything bigger is a resync rather than a movement: a tracking
+// glitch, or returning from a mode that does not run this code -- a bike ride
+// leaves the last sample stale for as long as you were riding. Swallow it
+// instead of teleporting the body.
+#define VR_MAX_HEAD_STEP 25.0f
 
-        deltaX = delta.x;
-        deltaY = delta.y;
-        deltaZ = delta.z;
+static void vr_rotate_vector_by_quaternion_inv(struct coord *v, const XrQuaternionf *q) {
+    XrQuaternionf inv;
+    inv.x = -q->x;
+    inv.y = -q->y;
+    inv.z = -q->z;
+    inv.w = q->w;
+    vr_rotate_vector_by_quaternion(v, &inv);
+}
 
-        // Calculate the proposed new position
-        newPos.x = g_Vars.currentplayer->prop->pos.x + deltaX;
-        newPos.y = g_Vars.currentplayer->prop->pos.y + deltaY;
-        newPos.z = g_Vars.currentplayer->prop->pos.z + deltaZ;
+// Camera position: the body plus wherever your head has leaned to.
+void vr_get_head_pos(struct coord *out) {
+    out->x = g_Vars.currentplayer->prop->pos.x + sVrHeadOffset.x;
+    out->y = g_Vars.currentplayer->prop->pos.y;
+    out->z = g_Vars.currentplayer->prop->pos.z + sVrHeadOffset.z;
+}
 
-        // Get the player's collision radius
-        playerGetBbox(g_Vars.currentplayer->prop, &radius, &ymax, &ymin);
+// 0 while the view is following your head, rising to 1 as your real head goes
+// further into something the view will not follow you into.
+f32 vr_get_head_clip_frac(void) {
+    f32 frac;
 
-        // Determine the collision types to check
-        types = g_Vars.bondcollisions ? CDTYPE_ALL : CDTYPE_BG;
-
-        // Get the rooms for the new position
-        func0f065e74(&g_Vars.currentplayer->prop->pos, g_Vars.currentplayer->prop->rooms, &newPos,
-                     rooms);
-        bmoveFindEnteredRoomsByPos(g_Vars.currentplayer, &newPos, rooms);
-
-        // Temporarily disable player collision to avoid self-collision
-        propSetPerimEnabled(g_Vars.currentplayer->prop, false);
-
-        // Check cylindrical collision for the new position
-        collisionResult = cdExamCylMove02(
-                &g_Vars.currentplayer->prop->pos,     // Current position
-                &newPos,                              // Destination position
-                radius,                               // Cylinder radius
-                rooms,                                // Rooms to check
-                types,                                           // Collision types
-                true,                                 // Check collisions
-                ymax - g_Vars.currentplayer->prop->pos.y,   // Maximum height
-                ymin - g_Vars.currentplayer->prop->pos.y    // Minimum height
-        );
-
-        // Re-enable player collision
-        propSetPerimEnabled(g_Vars.currentplayer->prop, true);
-
-        // Apply the movement ONLY if there is no collision
-        if (collisionResult == CDRESULT_NOCOLLISION) {
-            // No collision - apply full movement
-            g_Vars.currentplayer->prop->pos.x += deltaX;
-            g_Vars.currentplayer->prop->pos.y += deltaY;
-            g_Vars.currentplayer->prop->pos.z += deltaZ;
-
-            g_Vars.currentplayer->bond2.unk10.x += deltaX;
-            g_Vars.currentplayer->bond2.unk10.y += deltaY;
-            g_Vars.currentplayer->bond2.unk10.z += deltaZ;
-
-        } else {
-            // Collision detected
-            //vr_log("Collision detected");
-        }
-
-        // Save the current position
-        lastVRHeadPos.x = gHeadPos.x;
-        lastVRHeadPos.y = gHeadPos.y;
-        lastVRHeadPos.z = gHeadPos.z;
-
-    }else{
-        lastVRHeadPos.x = gHeadPos.x;
-        lastVRHeadPos.y = gHeadPos.y;
-        lastVRHeadPos.z = gHeadPos.z;
-
+    if (sVrHeadClipDist <= VR_HEAD_FADE_START) {
+        return 0.0f;
     }
+
+    frac = (sVrHeadClipDist - VR_HEAD_FADE_START) / (VR_HEAD_FADE_FULL - VR_HEAD_FADE_START);
+
+    return frac > 1.0f ? 1.0f : frac;
+}
+
+// Can the head sit this far from the body without ending up inside something
+// solid?
+//
+// Solid means "you cannot see through it". GEOFLAG_BLOCK_SIGHT is the level's
+// own answer to that question -- it is what the AI's line-of-sight tests use,
+// so every real wall carries it. The invisible barriers these levels put along
+// balconies and rails to keep the player in do not, because you can plainly
+// see through them, and blocking the head on those is what stopped leaning
+// over a rail from working. Geometry you can see through, your head goes
+// through; geometry you cannot, it does not.
+static bool vr_head_offset_is_clear(f32 offx, f32 offz) {
+    struct collision collisions[21];
+    struct coord headPos;
+    RoomNum rooms[8];
+    s32 types, i;
+
+    headPos.x = g_Vars.currentplayer->prop->pos.x + offx;
+    headPos.y = g_Vars.currentplayer->prop->pos.y;
+    headPos.z = g_Vars.currentplayer->prop->pos.z + offz;
+
+    types = g_Vars.bondcollisions ? CDTYPE_ALL : CDTYPE_BG;
+
+    func0f065e74(&g_Vars.currentplayer->prop->pos, g_Vars.currentplayer->prop->rooms, &headPos, rooms);
+    bmoveFindEnteredRoomsByPos(g_Vars.currentplayer, &headPos, rooms);
+
+    collisions[0].geo = NULL;
+
+    propSetPerimEnabled(g_Vars.currentplayer->prop, false);
+
+    cdCollectGeoForCylMove(&headPos, VR_HEAD_PROBE_RADIUS, rooms, types, GEOFLAG_WALL,
+                           true, VR_HEAD_PROBE_YMAX, VR_HEAD_PROBE_YMIN, collisions, 20);
+
+    propSetPerimEnabled(g_Vars.currentplayer->prop, true);
+
+    for (i = 0; collisions[i].geo != NULL; i++) {
+        if (collisions[i].geo->flags & GEOFLAG_BLOCK_SIGHT) {
+            return false;
+        }
+    }
+
+    // The test above only asks whether the head has ended up inside something,
+    // which a wall thinner than a lean is wide enough to step straight over:
+    // past its far side the destination is clear again and the view pops out
+    // the other side. Asking for line of sight from the body catches the
+    // crossing itself rather than the landing, and it is the same question --
+    // sight -- so invisible barriers stay invisible to it too.
+    if (!cdTestLos05(&g_Vars.currentplayer->prop->pos, g_Vars.currentplayer->prop->rooms,
+                     &headPos, rooms, types, GEOFLAG_BLOCK_SIGHT)) {
+        return false;
+    }
+
+    return true;
+}
+
+// Drag the body, full-body cylinder against the world as usual. Returns whether
+// it actually moved, so the caller can leave what was blocked in the offset.
+static bool vr_try_move_body(f32 dx, f32 dz) {
+    struct coord newPos;
+    RoomNum rooms[8];
+    f32 radius, ymax, ymin;
+    s32 types, result;
+
+    if (dx == 0.0f && dz == 0.0f) {
+        return false;
+    }
+
+    newPos.x = g_Vars.currentplayer->prop->pos.x + dx;
+    newPos.y = g_Vars.currentplayer->prop->pos.y;
+    newPos.z = g_Vars.currentplayer->prop->pos.z + dz;
+
+    playerGetBbox(g_Vars.currentplayer->prop, &radius, &ymax, &ymin);
+    types = g_Vars.bondcollisions ? CDTYPE_ALL : CDTYPE_BG;
+
+    func0f065e74(&g_Vars.currentplayer->prop->pos, g_Vars.currentplayer->prop->rooms, &newPos, rooms);
+    bmoveFindEnteredRoomsByPos(g_Vars.currentplayer, &newPos, rooms);
+
+    propSetPerimEnabled(g_Vars.currentplayer->prop, false);
+
+    result = cdExamCylMove02(&g_Vars.currentplayer->prop->pos, &newPos, radius, rooms, types, true,
+                             ymax - g_Vars.currentplayer->prop->pos.y,
+                             ymin - g_Vars.currentplayer->prop->pos.y);
+
+    propSetPerimEnabled(g_Vars.currentplayer->prop, true);
+
+    if (result != CDRESULT_NOCOLLISION) {
+        return false;
+    }
+
+    g_Vars.currentplayer->prop->pos.x = newPos.x;
+    g_Vars.currentplayer->prop->pos.z = newPos.z;
+
+    return true;
+}
+
+void vr_player_pos(void) {
+    struct coord physical;
+    struct coord shownPrev;
+    struct coord delta;
+    f32 dist;
+
+    if (g_Vars.currentplayer->isdead
+        || g_Vars.tickmode != TICKMODE_NORMAL
+        || vr_is_duel
+        || g_Vars.currentplayer->bondmovemode != MOVEMODE_WALK) {
+        // Riding, grabbing, dead or in a cutscene: glue the head back onto the
+        // body and just keep tracking, so the next live frame sees no jump.
+        sVrHeadOffsetPlay.x = 0.0f;
+        sVrHeadOffsetPlay.z = 0.0f;
+        sVrShownOffsetPlay.x = 0.0f;
+        sVrShownOffsetPlay.z = 0.0f;
+        sVrHeadOffset.x = 0.0f;
+        sVrHeadOffset.z = 0.0f;
+        sVrHeadClipDist = 0.0f;
+
+        lastVRHeadPos.x = gHeadPos.x;
+        lastVRHeadPos.y = gHeadPos.y;
+        lastVRHeadPos.z = gHeadPos.z;
+        return;
+    }
+
+    delta.x = gHeadPos.x - lastVRHeadPos.x;
+    delta.y = 0.0f;   // vertical is mapped absolutely by the eye height; it must not move the body
+    delta.z = gHeadPos.z - lastVRHeadPos.z;
+
+    if (fabsf(delta.x) > VR_MAX_HEAD_STEP || fabsf(delta.z) > VR_MAX_HEAD_STEP) {
+        delta.x = 0.0f;
+        delta.z = 0.0f;
+    }
+
+    lastVRHeadPos.x = gHeadPos.x;
+    lastVRHeadPos.y = gHeadPos.y;
+    lastVRHeadPos.z = gHeadPos.z;
+
+    // The physical offset takes the motion unconditionally: it is a record of
+    // where your head is, and nothing in the game may overrule that.
+    sVrHeadOffsetPlay.x += delta.x;
+    sVrHeadOffsetPlay.z += delta.z;
+
+    // Both offsets into game space. Rotating them separately is the same as
+    // rotating their sum, and both land in the world's current orientation.
+    physical.x = sVrHeadOffsetPlay.x;
+    physical.y = 0.0f;
+    physical.z = sVrHeadOffsetPlay.z;
+    vr_rotate_vector_by_quaternion(&physical, &vr_joy_rot_Q);
+
+    shownPrev.x = sVrShownOffsetPlay.x;
+    shownPrev.y = 0.0f;
+    shownPrev.z = sVrShownOffsetPlay.z;
+    vr_rotate_vector_by_quaternion(&shownPrev, &vr_joy_rot_Q);
+
+    // 1. Lean. The body's cylinder gets no say in where your head goes; the
+    //    only thing that may stop it is the head probe hitting something you
+    //    cannot see through, and then only along the axis that hit.
+    if (vr_head_offset_is_clear(physical.x, physical.z)) {
+        sVrHeadOffset.x = physical.x;
+        sVrHeadOffset.z = physical.z;
+    } else {
+        sVrHeadOffset.x = shownPrev.x;
+        sVrHeadOffset.z = shownPrev.z;
+
+        if (vr_head_offset_is_clear(physical.x, sVrHeadOffset.z)) {
+            sVrHeadOffset.x = physical.x;
+        }
+        if (vr_head_offset_is_clear(sVrHeadOffset.x, physical.z)) {
+            sVrHeadOffset.z = physical.z;
+        }
+    }
+
+    // 2. Walk. The body chases the head all the way back to zero, every tick.
+    //    It gets under you whenever it can; what it cannot do stays in the
+    //    offset, so the gap only ever exists because something solid is in the
+    //    way, and it closes by itself as soon as that stops being true.
+    dist = sqrtf(physical.x * physical.x + physical.z * physical.z);
+
+    if (dist > 0.0f) {
+        f32 rate = (dist > VR_BODY_CATCHUP_MAX) ? (VR_BODY_CATCHUP_MAX / dist) : 1.0f;
+        f32 dragx = physical.x * rate;
+        f32 dragz = physical.z * rate;
+
+        // The body moving under both offsets leaves the head where it is in the
+        // world, so whatever it manages comes off both of them equally.
+        if (vr_try_move_body(dragx, dragz)) {
+            physical.x -= dragx;
+            physical.z -= dragz;
+            sVrHeadOffset.x -= dragx;
+            sVrHeadOffset.z -= dragz;
+        } else {
+            // Blocked: slide along the surface instead of stopping dead, and
+            // consume only the component that actually moved.
+            if (vr_try_move_body(dragx, 0.0f)) {
+                physical.x -= dragx;
+                sVrHeadOffset.x -= dragx;
+            }
+            if (vr_try_move_body(0.0f, dragz)) {
+                physical.z -= dragz;
+                sVrHeadOffset.z -= dragz;
+            }
+        }
+    }
+
+    // What is left between where your head is and where the game will show it.
+    {
+        f32 clipx = physical.x - sVrHeadOffset.x;
+        f32 clipz = physical.z - sVrHeadOffset.z;
+        sVrHeadClipDist = sqrtf(clipx * clipx + clipz * clipz);
+    }
+
+    // Store both back in play space, where turning can rotate them for free.
+    sVrHeadOffsetPlay.x = physical.x;
+    sVrHeadOffsetPlay.y = 0.0f;
+    sVrHeadOffsetPlay.z = physical.z;
+    vr_rotate_vector_by_quaternion_inv(&sVrHeadOffsetPlay, &vr_joy_rot_Q);
+
+    sVrShownOffsetPlay.x = sVrHeadOffset.x;
+    sVrShownOffsetPlay.y = 0.0f;
+    sVrShownOffsetPlay.z = sVrHeadOffset.z;
+    vr_rotate_vector_by_quaternion_inv(&sVrShownOffsetPlay, &vr_joy_rot_Q);
 }
 
 
@@ -1578,16 +1805,32 @@ void bwalkUpdateVertical(void)
 
 
     if(!VrSeatedMode) {
-// VR Height
-        float VrMaxHeight = g_Vars.currentplayer->vv_height +
-                            g_Vars.currentplayer->vv_eyeheight * 0.0062893079593778f;
+// VR height: map the real head height above the physical floor into game units.
+// Nothing is remembered between frames, so a physical jump can no longer latch
+// a reference and leave you shorter for the session.
+//
+//   real height mode      one real cm is one game unit -- the scale the game
+//                         itself is modelled at, Joanna's eye sitting at 159
+//                         units for 1.59 m. The body you are wearing does not
+//                         come into it, so you are your own height in every
+//                         level. World scale applies, as it does to the IPD.
+//   character height mode your standing height maps onto the character's own
+//                         standing eye height (vv_eyeheight -- 159 for Joanna,
+//                         106 for Elvis, 175 for Mr Blonde), so standing up
+//                         puts your eye exactly where theirs is. World scale is
+//                         deliberately left out: the promise here is the
+//                         character's height relative to the level, and scaling
+//                         it would break that.
+        float unitsPerCm = VrMatchCharacterHeight
+                           ? (g_Vars.currentplayer->vv_eyeheight / VrPlayerHeight)
+                           : VrSetWorldScale;
 
-// Linear remapping: real world → game
-        float refHeight = (gStandingHeadHeight > 0.0f) ? gStandingHeadHeight : VrMaxHeight;
-        eyeheight = (gHeadPos.y / refHeight) * VrMaxHeight;
+        eyeheight = gVrHeadHeightCm * unitsPerCm;
 
-// Safety clamp (floor/ceiling)
-        if (eyeheight > VrMaxHeight) eyeheight = VrMaxHeight;
+// Sanity clamp against tracking glitches, not a height cap -- VR_MAX_HEAD_CM is
+// above any real tracked head. The ceiling check below is what keeps the view
+// out of level geometry.
+        if (eyeheight > VR_MAX_HEAD_CM * unitsPerCm) eyeheight = VR_MAX_HEAD_CM * unitsPerCm;
         if (eyeheight < 0.0f) eyeheight = 0.0f;
 
 // --- VR EYEHEIGHT DIVIDER TOGGLE (thumbstick click) ---
@@ -2484,7 +2727,11 @@ void bwalkTick(void)
         bmove0f0cc19c(&coord);
     }
     else {
-        bmove0f0cc19c(&g_Vars.currentplayer->prop->pos);
+        // VR: the camera sits at the head, which is the body plus however far
+        // you have physically leaned away from it.
+        struct coord headpos;
+        vr_get_head_pos(&headpos);
+        bmove0f0cc19c(&headpos);
     }
 
     playerUpdatePerimInfo();

--- a/src/game/mainmenu.c
+++ b/src/game/mainmenu.c
@@ -66,12 +66,17 @@ extern bool VRDebugMtxPos;
 //---
 static char gExtendedGameFovLabel[80];
 extern void vrSettingsSave();
+extern float gVrHeadHeightCm;   // live head height above the floor, cm
 //---
 #define HUD_STEREO_DEPTH_STEP  0.05f
 #define HUD_STEREO_DEPTH_STEPS ((s32)((HUD_STEREO_DEPTH_MAX - HUD_STEREO_DEPTH_MIN) / HUD_STEREO_DEPTH_STEP))
 //---
 #define WORLDSCALE_STEP   0.01f
 #define WORLDSCALE_STEPS  (s32)((WORLDSCALE_MAX - WORLDSCALE_MIN) / WORLDSCALE_STEP)
+
+// Your height slider steps in whole centimetres.
+#define PLAYERHEIGHT_STEPS (s32)(PLAYERHEIGHT_MAX - PLAYERHEIGHT_MIN)
+
 //--
 //---
 #define HUD_DISTANCE_STEP 0.05f
@@ -180,6 +185,61 @@ MenuItemHandlerResult menuhandlerVRWorldScale(s32 operation, struct menuitem *it
     return 0;
 }
 
+
+MenuItemHandlerResult menuhandlerVRCharacterHeight(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+    switch (operation) {
+        case MENUOP_GET:
+            return VrMatchCharacterHeight ? true : false;
+        case MENUOP_SET:
+            VrMatchCharacterHeight = data->checkbox.value ? true : false;
+            g_Vars.modifiedfiles |= MODFILE_GAME;
+            break;
+    }
+
+    return 0;
+}
+
+MenuItemHandlerResult menuhandlerVRPlayerHeight(s32 operation, struct menuitem *item, union handlerdata *data)
+{
+    static u8 lastRawValue = 0xFF;
+
+    switch (operation) {
+        case MENUOP_GETSLIDER:
+        {
+            s32 stepIndex = (s32)roundf(VrPlayerHeight - PLAYERHEIGHT_MIN);
+            data->slider.value = (u8)roundf((f32)stepIndex / (f32)PLAYERHEIGHT_STEPS * 255.0f);
+            lastRawValue = data->slider.value;
+        }
+            break;
+        case MENUOP_SET:
+        {
+            s32 delta = (s32)data->slider.value - (s32)lastRawValue;
+            if (delta != 0) {
+                s32 currentStep = (s32)roundf(VrPlayerHeight - PLAYERHEIGHT_MIN);
+                currentStep += delta > 0 ? 1 : -1;
+                if (currentStep < 0) currentStep = 0;
+                if (currentStep > PLAYERHEIGHT_STEPS) currentStep = PLAYERHEIGHT_STEPS;
+                VrPlayerHeight = PLAYERHEIGHT_MIN + (f32)currentStep;
+                g_Vars.modifiedfiles |= MODFILE_GAME;
+                lastRawValue = data->slider.value;
+            }
+        }
+            break;
+        case MENUOP_GETSLIDERLABEL:
+        {
+            // "now" is what the headset is reading this instant, so you can set
+            // the slider by standing up straight and matching it.
+            s32 measured = (s32)roundf(gVrHeadHeightCm);
+            if (measured < 0) measured = 0;
+            if (measured > 999) measured = 999;
+            sprintf(data->slider.label, "%d (now %d)", (s32)roundf(VrPlayerHeight), measured);
+        }
+            break;
+    }
+
+    return 0;
+}
 
 MenuItemHandlerResult menuhandlerVRWeaponRecoil(s32 operation, struct menuitem *item, union handlerdata *data)
 {
@@ -454,6 +514,26 @@ struct menuitem gVROptionsMenuItems[] = {
         (uintptr_t)"World Scale",
         0xff,
         menuhandlerVRWorldScale
+        },
+
+        // Your standing eye height, in cm
+        {
+        MENUITEMTYPE_SLIDER,
+        0,
+        MENUITEMFLAG_LITERAL_TEXT,
+        (uintptr_t)"Your Eye Height (cm)",
+        0xff,
+        menuhandlerVRPlayerHeight,
+        },
+
+        // Be the character's height instead of your own
+        {
+        MENUITEMTYPE_CHECKBOX,
+        0,
+        MENUITEMFLAG_LITERAL_TEXT,
+        (uintptr_t)"Match Character Height",
+        0,
+        menuhandlerVRCharacterHeight,
         },
 
         // VR Weapon Recoil

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -110,6 +110,7 @@ extern bool VrIsTitleLegal;
 extern int VrSmallW;
 extern int VrSmallH;
 extern void vr_player_rot();
+extern f32 vr_get_head_clip_frac(void);   // bondwalk.c: head-into-geometry comfort fade
 
 static s16 g_PrevAnimNumForContinuity = -1;
 static f32 g_RefHMDQuat[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
@@ -2603,6 +2604,41 @@ Gfx* playerDrawFade(Gfx* gdl, u32 r, u32 g, u32 b, f32 frac)
         gDPSetPrimColor(gdl++, 0, 0, r, g, b, (s32)(frac * 255));
         gDPFillRectangle(gdl++, viGetViewLeft(), viGetViewTop(),
                          viGetViewLeft() + viGetViewWidth(), viGetViewTop() + viGetViewHeight());
+        gDPPipeSync(gdl++);
+        gDPSetColorDither(gdl++, G_CD_BAYER);
+        gDPSetTexturePersp(gdl++, G_TP_PERSP);
+        gDPSetTextureLOD(gdl++, G_TL_LOD);
+    }
+
+    return gdl;
+}
+
+// playerDrawFade, but covering the whole field of view rather than the
+// viewport, which in a headset falls well short of the edges.
+//
+// 319x239 is not a typo and not the screen size: gfx_dp_fill_rectangle watches
+// for exactly that rect and widens it to roughly twice the screen in every
+// direction, a hack it already carries for widescreen fades. Going through
+// that instead of emitting the wide opcode directly matters -- the wide opcode
+// is two display list words, and however it is being consumed it only ever
+// reaches one eye, while ordinary fill rects (the damage flash, the death
+// wash) reach both.
+static Gfx* playerDrawFadeWide(Gfx* gdl, u32 r, u32 g, u32 b, f32 frac)
+{
+    if (frac > 0) {
+        gDPPipeSync(gdl++);
+        gDPSetCycleType(gdl++, G_CYC_1CYCLE);
+        gDPSetColorDither(gdl++, G_CD_DISABLE);
+        gDPSetTexturePersp(gdl++, G_TP_NONE);
+        gDPSetAlphaCompare(gdl++, G_AC_NONE);
+        gDPSetTextureLOD(gdl++, G_TL_TILE);
+        gDPSetTextureFilter(gdl++, G_TF_BILERP);
+        gDPSetTextureConvert(gdl++, G_TC_FILT);
+        gDPSetTextureLUT(gdl++, G_TT_NONE);
+        gDPSetRenderMode(gdl++, G_RM_CLD_SURF, G_RM_CLD_SURF2);
+        gDPSetCombineMode(gdl++, G_CC_PRIMITIVE, G_CC_PRIMITIVE);
+        gDPSetPrimColor(gdl++, 0, 0, r, g, b, (s32)(frac * 255));
+        gDPFillRectangle(gdl++, 0, 0, 319, 239);
         gDPPipeSync(gdl++);
         gDPSetColorDither(gdl++, G_CD_BAYER);
         gDPSetTexturePersp(gdl++, G_TP_PERSP);
@@ -5384,6 +5420,24 @@ Gfx* playerRenderHud(Gfx* gdl)
     }
 
     if (g_Vars.currentplayer->cameramode != CAMERAMODE_EYESPY) {
+        // VR: fade out as your real head pushes into something the view will
+        // not follow you into.
+        //
+        // Drawn before the HUD, not after. Everything below -- the weapon HUD,
+        // the radar, the messages -- opens capture regions that redirect
+        // drawing into other framebuffers, and a fade emitted after them only
+        // reached one eye, reliably in the campaign but not with a radar on
+        // screen. Ahead of them there is no capture state to inherit. It costs
+        // nothing visually: the HUD is composited as its own layer, so it sits
+        // on top of this either way.
+        {
+            f32 headclip = vr_get_head_clip_frac();
+
+            if (headclip > 0.0f) {
+                gdl = playerDrawFadeWide(gdl, 0, 0, 0, headclip);
+            }
+        }
+
         gdl = bgunDrawSight(gdl);
 
         if (bgunGetWeaponNum(HAND_RIGHT) == WEAPON_HORIZONSCANNER) {

--- a/src/game/playerreset.c
+++ b/src/game/playerreset.c
@@ -107,6 +107,10 @@ struct cmd32 {
 	s32 param3;
 };
 
+// VR: restart the head height calibration used when the runtime only offers a
+// LOCAL reference space. No-op with a floor-relative space.
+extern void vr_recalibrate_head_height(void);
+
 void playerReset(void)
 {
 	struct coord pos = {0, 0, 0};
@@ -126,6 +130,8 @@ void playerReset(void)
 
 	playerResetLoResIf4Mb();
 	func0f18e558();
+
+	vr_recalibrate_head_height();
 
 	g_InCutscene = false;
 

--- a/src/include/lib/collision.h
+++ b/src/include/lib/collision.h
@@ -46,6 +46,7 @@ RoomNum cdFindCeilingRoomYColourFlagsNormalAtPos(struct coord *pos, RoomNum *roo
 s32 cdTestVolume(struct coord *pos, f32 radius, RoomNum *rooms, s32 types, bool checkvertical, f32 ymax, f32 ymin);
 s32 cdExamCylMove01(struct coord *pos, struct coord *pos2, f32 radius, RoomNum *rooms, s32 types, bool checkvertical, f32 ymax, f32 ymin);
 s32 cdExamCylMove02(struct coord *origpos, struct coord *dstpos, f32 width, RoomNum *dstrooms, s32 types, bool checkvertical, f32 ymax, f32 ymin);
+void cdCollectGeoForCylMove(struct coord *pos, f32 width, RoomNum *rooms, u32 types, u16 geoflags, bool checkvertical, f32 ymax, f32 ymin, struct collision *collisions, s32 maxcollisions);
 bool cdTestCylMove01(struct coord *pos, RoomNum *rooms, struct coord *targetpos, u32 types, u32 arg4, f32 ymax, f32 ymin);
 s32 cdTestCylMove02(struct coord *pos, RoomNum *rooms, struct coord *coord2, RoomNum *rooms2, u32 types, bool arg5, f32 ymax, f32 ymin);
 s32 cdExamCylMove03(struct coord *pos, RoomNum *rooms, struct coord *arg2, u32 types, u32 arg4, f32 ymax, f32 ymin);


### PR DESCRIPTION
Two roomscale problems that turned out to share a root cause: physical head
motion was fed straight into the player's body position and height, as if
moving your head were locomotion.

### Permanent shrinking after a jump

Head height came from a session-lifetime high-water mark:

```c
if (gHeadPos.y > gStandingHeadHeight) { gStandingHeadHeight = gHeadPos.y; }
```

It only ever grew, and every later frame divided by it. Jump physically to 1.9 m
with a 1.7 m standing height and you were 1.7/1.9 ≈ **89% height for the rest of
the session**, across level loads — there was no reset path anywhere. It also fed
duck/squat detection, so the inflated reference made you spuriously crouch.

Height is now **mapped absolutely**. `LOCAL_FLOOR`/`STAGE` already report Y above
the physical floor, so one real centimetre is one game unit (the scale the game
is modelled at — Joanna's eye sits at 159 units for 1.59 m) and nothing is
remembered between frames. A jump has nothing to latch onto. Runtimes offering
only `LOCAL` fall back to a one-shot calibration at level start: the median head
Y over ~1 s — median rather than maximum precisely so a jump spike cannot move
it.

The `standheight` clamp in `bondhead.c` stays as a ceiling on the game body's
head bone, but with the high-water mark gone it can no longer corrupt any
reference.

### Two new settings

Both are genuinely per-player, so both are in the VR menu and persisted to
`pd-vr.ini`; everything else is baked as constants.

- **Your Eye Height (cm)** — your standing *eye* height, not your stature. The
  slider label shows a live reading beside the stored value, so you set it by
  standing up straight and matching the number. Duck and squat are measured
  against this, replacing the old latched reference.
- **Match Character Height** — off by default. Off, your own height carries into
  the game whatever body you are wearing. On, your standing pose maps onto the
  played character's own eye height, so Elvis is short and Mr Blonde towers, the
  way the N64 version reads them.

### Invisible walls when leaning

The same mistake horizontally. `vr_player_pos()` moved the whole body collision
cylinder by the head delta, so tipping your head over a waist-high rail drove
your capsule into it and the world stopped you dead. Worse, the blocked motion
was consumed anyway, so your real and virtual bodies desynced permanently and
the world appeared to shove you back.

The body and the head are now separate concepts:

- `prop->pos` is the **body** — collision, what the AI aims at, what owns rooms.
- The camera is the **head**, and still sits exactly where it always did, so the
  gun and hands (placed in view space off the camera matrix) needed no changes.

The body chases the head every tick, and *that* motion is what gets
collision-tested, so the walk-through-walls exploit stays closed. Distance
between the two opens up only where the body physically cannot follow — a rail
across its waist — and closes again as soon as the way is clear. Body motion is
invisible to the view, since camera = body + offset and both change by the same
vector.

What stops the head is a **head-sized probe at eye level testing
`GEOFLAG_BLOCK_SIGHT`** — the level's own answer to "can you see through this",
the same flag the AI's line-of-sight tests use. Real walls carry it and stop
your head; the invisible barriers these levels put along balconies and rails do
not, so they stop your body and let your head go over. That is what makes
leaning over a handrail work. A line-of-sight test from the body runs alongside
the destination test, because a destination-only test lets a fast lean step
clean over a thin wall and pop out the far side.

A physical offset is kept alongside the clamped one, so pressing into a wall and
stepping back converges again instead of leaving you permanently displaced.

Vertical physical motion no longer moves the body at all — height is mapped
absolutely now, so the old `deltaY` was redundant, and because it was applied
after the eye height was computed it was injecting a one-frame wobble into the
camera.

### Comfort fade

The view fades to black as your real head goes past what the game will follow.

One thing worth flagging for review: the fade is drawn **before** the HUD, not
after. Everything in that block — weapon HUD, radar, messages — opens capture
regions that redirect drawing into other framebuffers, and a fade emitted after
them reached only one eye. Reliably in the campaign, but only ~10% of the time
in Combat Simulator with the radar on. Drawn ahead of them it is correct every
time (tested 30+ times). It costs nothing visually, since the HUD is composited
as its own layer and sits on top either way.

It also uses the renderer's existing widescreen expansion (the `319x239` rect
`gfx_dp_fill_rectangle` watches for) so it covers the whole field of view. The
game's own full-screen effects — the damage flash, the death wash, light glares
— stop short of the periphery in a headset for want of the same treatment.
Deliberately left alone here, since `playerDrawFade` is shared with split-screen
where each player's fade should stop at their own viewport.

### Testing

Quest 3 over Virtual Desktop, `STAGE` reference space, single player and Combat
Simulator.

- Jump, land: height unchanged. Reload a level: nothing latched.
- Physical crouch to the floor: smooth, duck/squat trigger sensibly.
- Lean over a balcony handrail: the view goes over it, the body stays put.
- Lean into a solid wall: the head stops and the view fades; step back and you
  re-sync with no accumulated offset.
- Push hard and fast into a thin wall: no longer pops out the far side.
- Walk into a wall at an angle: slides along it.
- Roomscale-walk a full play space: no crossing geometry you shouldn't.

---

## Important Notes

- **The branch does not build standalone**, through no fault of this change:
  `upstream/port` at `62b683f7e` deleted `int vr_MpPause = 0;` from
  `gfx_pc.cpp` but left `mplayer.c` writing to it, so it does not link as
  shipped. I kept the one-line local patch out of this branch on purpose. If the
  maintainer's CI trips on it, that is the cause and it is theirs to fix.
