### PR TITLE
VR: remember the render resolution across restarts

### DIFF
--- a/port/src/video.c
+++ b/port/src/video.c
@@ -37,6 +37,9 @@ static struct GfxRenderingAPI *renderingAPI;
 
 static bool initDone = false;
 
+// VR: size of the desktop mirror window, kept in step with the eye render size. Only the
+// centering/fullscreen helpers below read these; the render resolution itself comes from
+// RENDER_SCALE, so they are runtime state and are not persisted to the config.
 s32 vidWidth = -1;
 s32 vidHeight = -1;
 
@@ -80,21 +83,7 @@ extern bool vr_configure_resolution();
 
 s32 videoInit(void)
 {
-#ifdef ANDROID
-    // Use SDL2 for Android since we're using SDLActivity
     wmAPI = &gfx_sdl;
-
-    // Get the actual screen dimensions on Android
-    SDL_DisplayMode displayMode;
-    if (SDL_GetCurrentDisplayMode(0, &displayMode) == 0) {
-        if (vidWidth == 0) vidWidth = displayMode.w;
-        if (vidHeight == 0) vidHeight = displayMode.h;
-        LOGI("Android: using screen dimensions %dx%d", vidWidth, vidHeight);
-    }
-#else
-    wmAPI = &gfx_sdl;
-
-#endif
     renderingAPI = &gfx_opengl_api;
 
     gfx_current_native_viewport.width = 320;
@@ -367,6 +356,13 @@ s32 videoInitDisplayModes(void)
     vidModeScales = scaleList;
     vidNumModes   = numModes;
 
+    // VR calls this again once it knows the eye render size; adopt it as the mirror-window
+    // size so the helpers below never run on a placeholder.
+    if (g_internalRenderWidth > 0 && g_internalRenderHeight > 0) {
+        vidWidth  = g_internalRenderWidth;
+        vidHeight = g_internalRenderHeight;
+    }
+
     return true;
 }
 
@@ -590,8 +586,6 @@ PD_CONSTRUCTOR static void videoConfigInit(void)
 {
     configRegisterInt("Video.DefaultFullscreen", &vidFullscreen, 0, 1);
     configRegisterInt("Video.DefaultMaximize", &vidMaximize, 0, 1);
-    configRegisterInt("Video.DefaultWidth", &vidWidth, 0, 32767);
-    configRegisterInt("Video.DefaultHeight", &vidHeight, 0, 32767);
     configRegisterInt("Video.ExclusiveFullscreen", &vidFullscreenExclusive, 0, 1);
     configRegisterInt("Video.CenterWindow", &vidCenter, 0, 1);
     configRegisterInt("Video.AllowHiDpi", &vidAllowHiDpi, 0, 1);
@@ -604,4 +598,9 @@ PD_CONSTRUCTOR static void videoConfigInit(void)
     configRegisterInt("Video.TextureFilter", &texFilter, 0, 2);
     configRegisterInt("Video.TextureFilter2D", &texFilter2D, 0, 1);
     configRegisterInt("Video.DetailTextures", &texDetail, 0, 1);
+    // VR: the eye render resolution is derived from RENDER_SCALE, so this is the key that
+    // makes the Extended menu's Resolution choice survive a restart. configInit() runs long
+    // before vr_initialize(), so the saved scale is already in place when the swapchains are
+    // first sized -- no restart and no resolution pop on startup.
+    configRegisterFloat("Video.VRRenderScale", &RENDER_SCALE, 0.5f, 4.f);
 }


### PR DESCRIPTION
The Extended menu's Resolution setting was lost on every launch, always falling back
to 1832x1868 (RENDER_SCALE 1.0) no matter what had been picked.

The eye render resolution is derived from RENDER_SCALE in `vr_initialize()`
(`g_internalRenderWidth = VR_FIXED_WIDTH * RENDER_SCALE`), but RENDER_SCALE was a
plain global initialised to 1.0f and never persisted, so nothing carried the choice
over to the next run.

### What this does

Registers it with the config system as `Video.VRRenderScale`. `configInit()` runs well
before `vr_initialize()` is first called from `mainTick()`, so the saved scale is
already in place when the swapchains are sized — no restart and no resolution pop on
startup. `configSave()` at shutdown persists it, and the menu highlights the right
entry because `videoGetDisplayModeIndex()` matches the window size that
`vr_initialize()` derives from the same scale.

### Also drops `Video.DefaultWidth` / `Video.DefaultHeight`

They looked like the resolution setting and were the obvious place to go looking when
it did not stick, but they have no effect in the VR build: `videoSetDisplayMode()`
wrote them and `configSave()` stored them, yet nothing read them back at boot. The
window is sized from `VrRecommendedW/H` in `videoInit()`, `gfx_sdl_init()` overwrites
`window_width/height` with the same, and `vr_initialize()` then resizes to
`g_internalRenderWidth/Height`.

`vidWidth`/`vidHeight` stay on as runtime state — the centering and fullscreen helpers
still use them as the mirror-window size — and are now seeded from the eye render size
in `videoInitDisplayModes()`, which VR calls once that size is known. That replaces the
config load that used to give them their initial value, so they are never read as a
placeholder.

Removing the keys also makes the Android block in `videoInit()` dead: its
`vidWidth == 0` test was only ever reachable via `DefaultWidth=0` in the ini, and with
the key gone `vidWidth` keeps its `-1` initialiser. With that block out, both halves of
the `#ifdef ANDROID` were identical, so it collapses to the single assignment.

### Compatibility

Existing configs need no migration: `configLoad()` ignores unknown keys and the next
`configSave()` drops the stale lines.
```

---
