### PR TITLE
VR: let full-screen effects cover the whole field of view

### DIFF
--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -87,6 +87,12 @@ void   vr_end_eye_render();
 float* vr_get_eye_proj_mtx(int eye);
 void   vr_get_eye_view_offset(int eye, float* out_tx, float* out_ty, float* out_tz, float *out_tx_HUD);
 bool vr_dl_is_pause_or_menu = false;
+// True only between the menu's begin and end tags, unlike vr_dl_is_pause_or_menu
+// which latches on at the first menu and never clears (the game emits an end tag
+// for it, 0x56520000, that nothing handles). Left that alone deliberately: it
+// drives uIsMenu in the shader, so unlatching it would move the HUD parallax
+// mid-session. This is the flag to use for "menu content is being drawn now".
+static bool vr_dl_menu_scope = false;
 int VrIsPaused = 0;
 static float s_vr_proj_col_major[16] = {};
 extern "C" int vr_get_internal_render_width();
@@ -2227,6 +2233,47 @@ static void gfx_dp_image_rectangle(int32_t tile, int32_t w, int32_t h,
                                    int32_t lrx, int32_t lry, int16_t lrs, int16_t lrt) {
     uint64_t saved_combine_mode = rdp.combine_mode;
 
+    // Widen a full-viewport image rect exactly as gfx_dp_fill_rectangle widens a
+    // full-viewport fill rect, and for the same reason: the headset sees past
+    // the viewport, so the motion blur and the cutscene wash that ride on this
+    // opcode stopped short and left strips down the sides. The difference is
+    // that the source coordinates have to grow by the same proportion, or the
+    // captured frame would be stretched across the bigger rect rather than
+    // extended past it -- the blur has to stay registered with the scene under
+    // it. Sampling then runs off the edge of the capture, so the tile is
+    // clamped below and the edge pixels carry outward.
+    //
+    // Not for menus. The blurred backdrop behind the pause and title menus is
+    // the same opcode over the same captured frame, but it is a deliberate
+    // treatment of that image rather than an overlay on the world, and widening
+    // it garbles the backdrop.
+    bool vr_widened = false;
+
+    if (vr_is_initialized()
+            && !vr_dl_menu_scope
+            && ulx <= 0 && uly <= 0
+            && lrx >= (SCREEN_WIDTH - 1) * 4 && lry >= (SCREEN_HEIGHT - 1) * 4
+            && lrx > ulx && lry > uly) {
+        const int32_t newulx = -2 * 4 * SCREEN_WIDTH;
+        const int32_t newuly = -2 * 4 * SCREEN_HEIGHT;
+        const int32_t newlrx =  3 * 4 * SCREEN_WIDTH;
+        const int32_t newlry =  3 * 4 * SCREEN_HEIGHT;
+
+        const float texelsx = (float)(lrs - uls) / (float)(lrx - ulx);
+        const float texelsy = (float)(lrt - ult) / (float)(lry - uly);
+
+        uls = (int16_t)(uls + (newulx - ulx) * texelsx);
+        lrs = (int16_t)(lrs + (newlrx - lrx) * texelsx);
+        ult = (int16_t)(ult + (newuly - uly) * texelsy);
+        lrt = (int16_t)(lrt + (newlry - lry) * texelsy);
+
+        ulx = newulx;
+        uly = newuly;
+        lrx = newlrx;
+        lry = newlry;
+
+        vr_widened = true;
+    }
 
     struct LoadedVertex* ul = &rsp.loaded_vertices[MAX_VERTICES + 0];
     struct LoadedVertex* ll = &rsp.loaded_vertices[MAX_VERTICES + 1];
@@ -2245,8 +2292,10 @@ static void gfx_dp_image_rectangle(int32_t tile, int32_t w, int32_t h,
     rdp.texture_tile[tile].line_size_bytes = w << rdp.texture_tile[tile].siz >> 1;
     rdp.texture_tile[tile].width = w;
     rdp.texture_tile[tile].height = h;
-    rdp.texture_tile[tile].cms = 0;
-    rdp.texture_tile[tile].cmt = 0;
+    // Clamp rather than wrap once widened, so the area past the captured frame
+    // carries its edge pixels outward instead of tiling copies of it.
+    rdp.texture_tile[tile].cms = vr_widened ? G_TX_CLAMP : 0;
+    rdp.texture_tile[tile].cmt = vr_widened ? G_TX_CLAMP : 0;
     rdp.texture_tile[tile].shifts = 0;
     rdp.texture_tile[tile].shiftt = 0;
     auto& loadtex = rdp.loaded_texture[rdp.texture_tile[tile].tmem];
@@ -2277,12 +2326,26 @@ static void gfx_dp_fill_rectangle(int32_t ulx, int32_t uly, int32_t lrx, int32_t
     }
     uint32_t mode = (rdp.other_mode_h & (3U << G_MDSFT_CYCLETYPE));
 
-    // OTRTODO: This is a bit of a hack for widescreen screen fades, but it'll work for now...
-    if (ulx == 0 && uly == 0 && lrx == 319 * 4 && lry == 239 * 4) {
-        ulx = -1024;
-        uly = -1024;
-        lrx = 2048;
-        lry = 2048;
+    // A fill rect covering the whole viewport is a screen-wide effect -- a fade,
+    // a damage flash, a wash -- so widen it well past the viewport. Widescreen
+    // needs that to reach the corners; a headset needs it more, because it sees
+    // past the viewport entirely and a rect stopping there leaves a visible edge
+    // in your periphery.
+    //
+    // These are 10.2 fixed point coordinates that gfx_draw_rectangle maps to NDC
+    // through HALF_SCREEN_WIDTH, so the old fixed -1024..2048 was really "-2.6 to
+    // +2.2 in NDC" only at a 320-wide native viewport. At 576 the same numbers
+    // land the right edge at +0.78 -- inside the screen, hence a strip along the
+    // right that no full-screen effect ever covered. Expressed in screens it
+    // holds at any native size.
+    if ((ulx == 0 && uly == 0 && lrx == 319 * 4 && lry == 239 * 4)
+            || (vr_is_initialized()
+                && ulx <= 0 && uly <= 0
+                && lrx >= (SCREEN_WIDTH - 1) * 4 && lry >= (SCREEN_HEIGHT - 1) * 4)) {
+        ulx = -2 * 4 * SCREEN_WIDTH;
+        uly = -2 * 4 * SCREEN_HEIGHT;
+        lrx =  3 * 4 * SCREEN_WIDTH;
+        lry =  3 * 4 * SCREEN_HEIGHT;
     }
 
     if (mode == G_CYC_COPY || mode == G_CYC_FILL) {
@@ -2374,6 +2437,11 @@ static void gfx_run_dl(Gfx* cmd) {
                 switch (tag_w1) {
                     case 0x56520001: // Menu is open
                         vr_dl_is_pause_or_menu = (tag_w1 & 0xFFFF) != 0; // VR
+                        vr_dl_menu_scope = true;
+                        break;
+
+                    case 0x56520000: // Menu is finished
+                        vr_dl_menu_scope = false;
                         break;
 
                     case VR_MENU_HUD_CAPTURE_BEGIN_L:

--- a/src/game/bondview.c
+++ b/src/game/bondview.c
@@ -740,12 +740,27 @@ Gfx *bviewDrawFisheye(Gfx *gdl, u32 colour, u32 alpha, s32 shuttertime60, s8 sta
 
     gDPPipeSync(gdl++);
 
-    gdl = bviewPrepareStaticRgba16(gdl, colour, alpha);
-
 #ifndef PLATFORM_N64
     // make a copy of the current back buffer contents that we will be using as a texture
     gDPFlushEXT(gdl++);
     gDPCopyFramebufferEXT(gdl++, g_PrevFrameFb, 0, 0, 0, G_ON);
+
+    // VR: black out the whole field of view, after the snapshot above and
+    // before the lens is drawn from it.
+    //
+    // The camera surround is masked per scanline by bviewDrawFisheyeRect, which
+    // can only ever reach the viewport: fill rect coordinates are packed into 10
+    // bits, so nothing outside 0..1023 can even be addressed. That left the world
+    // showing all around the camera frame in a headset, which sees well past the
+    // viewport. A full-viewport rect is widened by the renderer to cover the eye,
+    // and taking the snapshot first means the lens still samples the clean scene
+    // rather than this black.
+    gdl = playerDrawFade(gdl, 0, 0, 0, 1.0f);
+#endif
+
+    gdl = bviewPrepareStaticRgba16(gdl, colour, alpha);
+
+#ifndef PLATFORM_N64
     gDPSetFramebufferTextureEXT(gdl++, 0, 0, 0, g_PrevFrameFb);
 #endif
 

--- a/src/game/nbomb.c
+++ b/src/game/nbomb.c
@@ -839,10 +839,15 @@ Gfx *nbombRenderOverlay(Gfx *gdl)
 		colours = gfxAllocateColours(1);
 		vertices = gfxAllocateVertices(4);
 
-		viewleft = viGetViewLeft() * 10;
-		viewtop = viGetViewTop() * 10;
-		viewright = (s16) (viGetViewLeft() + viGetViewWidth()) * 10;
-		viewbottom = (s16) (viGetViewTop() + viGetViewHeight()) * 10;
+		// VR: the headset sees well past the game viewport, so an overlay that
+		// stops at the viewport leaves its edge sitting in your periphery.
+		// Grow the quad by a whole view in every direction. The texture
+		// coordinates below grow by the same factor, so the gas keeps its
+		// density instead of being stretched across the larger quad.
+		viewleft = viGetViewLeft() * 10 - viGetViewWidth() * 10;
+		viewtop = viGetViewTop() * 10 - viGetViewHeight() * 10;
+		viewright = (s16) (viGetViewLeft() + viGetViewWidth()) * 10 + viGetViewWidth() * 10;
+		viewbottom = (s16) (viGetViewTop() + viGetViewHeight()) * 10 + viGetViewHeight() * 10;
 
 		s = (s32) (8.0f * g_20SecIntervalFrac * 128.0f * 32.0f) % 2048;
 		t = (s16) ((s32) (campos.f[1] * 8.0f) % 2048) + (s16) (2.0f * g_20SecIntervalFrac * 128.0f * 32.0f);
@@ -884,14 +889,15 @@ Gfx *nbombRenderOverlay(Gfx *gdl)
 		vertices[3].y = viewbottom;
 		vertices[3].z = -10;
 
+		// 3x the original 160/960 spans, matching the 3x quad above.
 		vertices[0].s = s;
 		vertices[0].t = t;
-		vertices[1].s = s + 160;
+		vertices[1].s = s + 480;
 		vertices[1].t = t;
-		vertices[2].s = s + 160;
-		vertices[2].t = t + 960;
+		vertices[2].s = s + 480;
+		vertices[2].t = t + 2880;
 		vertices[3].s = s;
-		vertices[3].t = t + 960;
+		vertices[3].t = t + 2880;
 
 		vertices[0].colour = 0;
 		vertices[1].colour = 0;
@@ -993,10 +999,16 @@ Gfx *gasRender(Gfx *gdl)
 		if (show) {
 			Col *colours = gfxAllocateColours(1);
 			Vtx *vertices = gfxAllocateVertices(8);
-			s16 viewleft = viGetViewLeft() * 10;
-			s16 viewtop = viGetViewTop() * 10;
-			s16 viewright = (s16) (viGetViewLeft() + viGetViewWidth()) * 10;
-			s16 viewbottom = (s16) (viGetViewTop() + viGetViewHeight()) * 10;
+			// Grown by a whole view in every direction, as the N-bomb overlay
+			// above is and for the same reason: the headset sees past the game
+			// viewport, so a quad that stops there leaves its edge in your
+			// periphery. Both layers' texture coordinates grow to match, so the
+			// gas keeps its density instead of being stretched over the larger
+			// quad.
+			s16 viewleft = viGetViewLeft() * 10 - viGetViewWidth() * 10;
+			s16 viewtop = viGetViewTop() * 10 - viGetViewHeight() * 10;
+			s16 viewright = (s16) (viGetViewLeft() + viGetViewWidth()) * 10 + viGetViewWidth() * 10;
+			s16 viewbottom = (s16) (viGetViewTop() + viGetViewHeight()) * 10 + viGetViewHeight() * 10;
 			f32 lookx = g_Vars.currentplayer->cam_look.x;
 			f32 lookz = g_Vars.currentplayer->cam_look.z;
 			f32 camposx = g_Vars.currentplayer->cam_pos.x;
@@ -1070,28 +1082,30 @@ Gfx *gasRender(Gfx *gdl)
 			vertices[7].y = viewbottom;
 			vertices[7].z = -10;
 
+			// 3x the original 960/640 spans, matching the 3x quad above.
 			vertices[0].s = layer1s;
 			vertices[0].t = layer1t;
-			vertices[1].s = layer1s + 960;
+			vertices[1].s = layer1s + 2880;
 			vertices[1].t = layer1t;
-			vertices[2].s = layer1s + 960;
-			vertices[2].t = layer1t + 640;
+			vertices[2].s = layer1s + 2880;
+			vertices[2].t = layer1t + 1920;
 			vertices[3].s = layer1s;
-			vertices[3].t = layer1t + 640;
+			vertices[3].t = layer1t + 1920;
 
 			vertices[0].colour = 0;
 			vertices[1].colour = 0;
 			vertices[2].colour = 0;
 			vertices[3].colour = 0;
 
+			// 3x the original 640/480 spans, likewise.
 			vertices[4].s = layer2s;
 			vertices[4].t = layer2t;
-			vertices[5].s = layer2s + 640;
+			vertices[5].s = layer2s + 1920;
 			vertices[5].t = layer2t;
-			vertices[6].s = layer2s + 640;
-			vertices[6].t = layer2t + 480;
+			vertices[6].s = layer2s + 1920;
+			vertices[6].t = layer2t + 1440;
 			vertices[7].s = layer2s;
-			vertices[7].t = layer2t + 480;
+			vertices[7].t = layer2t + 1440;
 
 			vertices[4].colour = 0;
 			vertices[5].colour = 0;


### PR DESCRIPTION
Fades, damage flashes, washes, the motion blur and the N-bomb gas all stopped
short of the headset's field of view, leaving the edge of the effect sitting in
your periphery — a hard rectangle with the world still visible around it.

### One constant behind all of it

`gfx_dp_fill_rectangle` already widens a full-screen fade so it still reaches
the corners in widescreen, but the widened bounds were fixed:

```c
if (ulx == 0 && uly == 0 && lrx == 319 * 4 && lry == 239 * 4) {
    ulx = -1024; uly = -1024; lrx = 2048; lry = 2048;
}
```

Those are 10.2 fixed point coordinates that `gfx_draw_rectangle` maps to NDC
through `HALF_SCREEN_WIDTH`, so what they actually mean depends on the native
viewport:

| native viewport | left edge | right edge |
|---|---|---|
| 320 | −2.60 | **+2.20** ✓ |
| 576 | −1.89 | **+0.78** ✗ |

At 576 the right edge lands *inside* the screen, so a strip down the right was
never covered by any full-screen effect. Expressed in screens rather than fixed
numbers it holds at any native size — and two headsets with different native
viewports stop disagreeing with each other about where effects end.

### The motion blur needed more than that

The motion blur and the cutscene wash draw through `gfx_dp_image_rectangle`,
re-projecting a captured frame. Widening the destination alone would scale the
captured frame up to fill the larger rect instead of extending it, so the blur
would sit out of register with the scene beneath it. The source coordinates grow
by the same proportion as the destination instead.

That makes sampling run off the edge of the capture, so widened draws clamp
rather than wrap — the frame's edge pixels carry outward, instead of the texture
tiling visible copies of the scene into the periphery.

### Menus are excluded, and that needed a new flag

The blurred backdrop behind the pause and title menus is the same opcode over
the same captured frame, but it is a deliberate treatment of that image rather
than an overlay on the world, and widening it garbles it.

`vr_dl_is_pause_or_menu` could not be used to detect that. The game emits an end
tag for it — `0x56520000`, at the end of `menuRender` — that the display list
switch has no case for, so the flag latches on at the first menu and never
clears. **This PR does not fix that latch**, because the flag drives `uIsMenu` in
the shader and unlatching it would move the HUD parallax mid-session, which
deserves its own change and its own testing. A second flag tracks menu scope
properly and is used here instead.

### The N-bomb gas reaches neither opcode

It builds a textured quad from the view bounds directly, so it grows its own
quad by a view in every direction. The texture coordinates are scaled to match,
so the gas keeps its density rather than being stretched coarser over the
larger area.

### Testing

Quest 3 and PSVR2, single player and Combat Simulator, radar on and off:

- damage flash, death wash, level transitions, cutscene washes, lens flares,
  the motion blur and the N-bomb gas all reach the edges on both headsets
- pause, title and Carrington Institute menu backdrops unchanged
- effects behave identically on the two headsets, which they did not before

---


