### PR TITLE
VR: cull against the per-eye frusta, not the averaged one

### DIFF
--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -99,6 +99,58 @@ bool is_weapon_hud = false;
 extern "C" void gfxSetCrosshairParallaxRight(float correction);
 extern "C" void gfxSetCrosshairParallaxLeft(float correction);
 
+// --- VR: culling has to account for the per-eye clip-space shear -------------
+//
+// Vertices are transformed on the CPU with the game's projection, which is a
+// single symmetric frustum built from the mean of the two eyes' tangent extents.
+// The multiview vertex shader then shears clip space per eye:
+//
+//     x' = x - ex - ey * w        ex = IPD offset, ey = horizontal lens asymmetry
+//     y' = y - ew * w             ew = vertical lens asymmetry
+//
+// So the frustum the CPU culls against matches neither eye. Two tests below are
+// corrected with the values the shader itself is given, rather than a guess.
+// All of these stay zero outside VR, where the corrections reduce to identities.
+
+// Trivial reject: how far beyond the unsheared frustum a vertex may sit and
+// still be visible to one of the eyes. The constant term is the IPD offset; the
+// w-scaled term covers the lens asymmetry and the HUD branch's own shear.
+static float vr_clip_margin_x_const = 0.0f;
+static float vr_clip_margin_x_w = 0.0f;
+static float vr_clip_margin_y_w = 0.0f;
+
+// Backface winding: only ex survives the differencing of the cross product (ey
+// and ew are constant per vertex and cancel), so this is all the cull test needs.
+static float vr_cull_eye_dx[2] = { 0.0f, 0.0f };
+static bool vr_cull_stereo = false;
+
+static void vr_set_cull_offsets(const float offsets[8]) {
+    // Layout per eye, from gfx_opengl_set_eye_offsets: { ipd, asym_x, hud, asym_y }.
+    const float exL = offsets[0], eyL = offsets[1], ezL = offsets[2], ewL = offsets[3];
+    const float exR = offsets[4], eyR = offsets[5], ezR = offsets[6], ewR = offsets[7];
+
+    vr_clip_margin_x_const = std::max(std::fabs(exL), std::fabs(exR));
+    vr_clip_margin_x_w = std::max(std::max(std::fabs(eyL), std::fabs(eyR)),
+                                  std::max(std::fabs(ezL), std::fabs(ezR)));
+    vr_clip_margin_y_w = std::max(std::fabs(ewL), std::fabs(ewR));
+
+    vr_cull_eye_dx[0] = exL;
+    vr_cull_eye_dx[1] = exR;
+    vr_cull_stereo = (exL != exR);
+
+    // The margins are only as good as the asymmetry the runtime reports, and that
+    // differs per headset. Log them once so they can be read back rather than
+    // assumed.
+    static bool logged = false;
+    if (!logged) {
+        logged = true;
+        vr_log("VR cull offsets: L ipd=%.4f asym_x=%.4f hud=%.4f asym_y=%.4f", exL, eyL, ezL, ewL);
+        vr_log("VR cull offsets: R ipd=%.4f asym_x=%.4f hud=%.4f asym_y=%.4f", exR, eyR, ezR, ewR);
+        vr_log("VR clip margins: x_const=%.4f x_w=%.4f y_w=%.4f",
+               vr_clip_margin_x_const, vr_clip_margin_x_w, vr_clip_margin_y_w);
+    }
+}
+
 //------------------------------------------------------------------------------
 
 struct RGBA {
@@ -1181,17 +1233,26 @@ static void gfx_sp_vertex(size_t n_vertices, size_t dest_index, const Vtx* verti
         d->v = V;
 
         // trivial clip rejection
+        //
+        // The bounds are widened by however far the per-eye shear can carry a
+        // vertex back into view (zero outside VR). Being generous here only
+        // costs a few triangles the GPU then clips; being tight drops geometry
+        // the headset can see, in a strip down the outer edge of each eye.
+        const float aw = fabsf(w);
+        const float mx = vr_clip_margin_x_const + vr_clip_margin_x_w * aw;
+        const float my = vr_clip_margin_y_w * aw;
+
         d->clip_rej = 0;
-        if (x < -w) {
+        if (x < -w - mx) {
             d->clip_rej |= 1; // CLIP_LEFT
         }
-        if (x > w) {
+        if (x > w + mx) {
             d->clip_rej |= 2; // CLIP_RIGHT
         }
-        if (y < -w) {
+        if (y < -w - my) {
             d->clip_rej |= 4; // CLIP_BOTTOM
         }
-        if (y > w) {
+        if (y > w + my) {
             d->clip_rej |= 8; // CLIP_TOP
         }
         // if (z < -w) d->clip_rej |= 16; // CLIP_NEAR
@@ -1243,6 +1304,27 @@ static inline int gfx_lod_tile_offset(const int i) {
     return (rdp.tex_lod ? rdp.tex_detail : i);
 }
 
+// Signed area of the triangle as one eye sees it. eye_dx is that eye's clip-space
+// IPD offset: the shader's shear is x' = x - ex - ey*w, and the constant ey drops
+// out of the differences, so subtracting ex is the whole correction. Called with
+// eye_dx == 0 outside VR, where it is the stock centre-camera cross product.
+static inline float gfx_tri_signed_area(const struct LoadedVertex* v1, const struct LoadedVertex* v2,
+                                        const struct LoadedVertex* v3, float eye_dx) {
+    float dx1 = (v1->x - eye_dx) / (v1->w) - (v2->x - eye_dx) / (v2->w);
+    float dy1 = v1->y / (v1->w) - v2->y / (v2->w);
+    float dx2 = (v3->x - eye_dx) / (v3->w) - (v2->x - eye_dx) / (v2->w);
+    float dy2 = v3->y / (v3->w) - v2->y / (v2->w);
+    float cross = dx1 * dy2 - dy1 * dx2;
+
+    if ((v1->w < 0) ^ (v2->w < 0) ^ (v3->w < 0)) {
+        // If one vertex lies behind the eye, negating cross will give the correct result.
+        // If all vertices lie behind the eye, the triangle will be rejected anyway.
+        cross = -cross;
+    }
+
+    return cross;
+}
+
 static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bool is_rect) {
     struct LoadedVertex* v1 = &rsp.loaded_vertices[vtx1_idx];
     struct LoadedVertex* v2 = &rsp.loaded_vertices[vtx2_idx];
@@ -1257,16 +1339,25 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
     }
 
     if ((rsp.geometry_mode & G_CULL_BOTH) != 0) {
-        float dx1 = v1->x / (v1->w) - v2->x / (v2->w);
-        float dy1 = v1->y / (v1->w) - v2->y / (v2->w);
-        float dx2 = v3->x / (v3->w) - v2->x / (v2->w);
-        float dy2 = v3->y / (v3->w) - v2->y / (v2->w);
-        float cross = dx1 * dy2 - dy1 * dx2;
+        if ((rsp.geometry_mode & G_CULL_BOTH) == G_CULL_BOTH) {
+            // Why is this even an option?
+            return;
+        }
 
-        if ((v1->w < 0) ^ (v2->w < 0) ^ (v3->w < 0)) {
-            // If one vertex lies behind the eye, negating cross will give the correct result.
-            // If all vertices lie behind the eye, the triangle will be rejected anyway.
-            cross = -cross;
+        const bool cull_front = (rsp.geometry_mode & G_CULL_BOTH) == G_CULL_FRONT;
+
+        // The two eyes do not agree about the winding of a triangle that is close
+        // to edge-on, because their parallax is depth-dependent and so does not
+        // cancel out of the cross product. Multiview gives us one vertex stream for
+        // both views, so a triangle either survives for both eyes or for neither:
+        // keep it if either eye sees its front. Where the eyes disagree the other
+        // one is looking at a degenerate sliver, so drawing it there costs nothing.
+        float cross = gfx_tri_signed_area(v1, v2, v3, vr_cull_eye_dx[0]);
+        bool cull = cull_front ? (cross <= 0) : (cross >= 0);
+
+        if (cull && vr_cull_stereo) {
+            cross = gfx_tri_signed_area(v1, v2, v3, vr_cull_eye_dx[1]);
+            cull = cull_front ? (cross <= 0) : (cross >= 0);
         }
 
         // If inverted culling is requested, negate the cross
@@ -1274,20 +1365,8 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
         //     cross = -cross;
         // }
 
-        switch (rsp.geometry_mode & G_CULL_BOTH) {
-            case G_CULL_FRONT:
-                if (cross <= 0) {
-                    return;
-                }
-                break;
-            case G_CULL_BACK:
-                if (cross >= 0) {
-                    return;
-                }
-                break;
-            case G_CULL_BOTH:
-                // Why is this even an option?
-                return;
+        if (cull) {
+            return;
         }
     }
 
@@ -2869,6 +2948,11 @@ extern "C" void gfx_run(Gfx* commands) {
 
         gfx_rapi->set_eye_offsets(offsets[0], offsets[1], offsets[2], offsets[3],
                                   offsets[4], offsets[5], offsets[6], offsets[7]);
+
+        // Feed the same numbers to the CPU-side clip and backface tests, so they
+        // cull against the frusta the shader actually renders rather than the
+        // centred average frustum the game's projection matrix describes.
+        vr_set_cull_offsets(offsets);
 
 
         // 1) Acquire + attach swapchain to g_multiviewFBO


### PR DESCRIPTION
Solves #66 

Geometry popped in and out at the outer edge of each eye, and surfaces close to
edge-on — the right side of the Falcon 2's slide, held right in front of you —
flickered away entirely. Both come from the same place.

### One frustum, two eyes

Vertices are transformed on the CPU with the game's projection matrix, and that
matrix is a single *symmetric* frustum built from the mean of the two eyes'
tangent extents:

```c
tanHalfWidthSum += (tanf(fov.angleRight) - tanf(fov.angleLeft)) * 0.5f;
```

The multiview vertex shader then shears clip space per eye:

```glsl
mvPos.x -= eyeOffset.x + (eyeOffset.y * mvPos.w);   // IPD + horizontal lens asymmetry
mvPos.y -= eyeOffset.w * mvPos.w;                   // vertical lens asymmetry
```

So the frustum `gfx_sp_vertex` and `gfx_sp_tri1` cull against matches neither eye.
Both tests are corrected here with the offsets the shader itself is handed, so
there is no new constant to tune and nothing that needs adjusting per headset.

### The trivial reject was cutting a strip off each eye

`clip_rej` tested `x < -w` / `x > w`. After the shear the visible range is
`ex + (ey−1)·w ≤ x ≤ ex + (ey+1)·w`, so anything in between was dropped despite
being visible. `ey` is the lens asymmetry, `(tanR+tanL)/(tanR−tanL)` — **0.32**
on the headset this was measured on, whose eye 0 runs `left=-61.5°` to
`right=+43.4°`. That is a strip roughly 13% of the image width down the outer
edge of each eye where geometry was culled but on screen.

The bounds now widen by however far the shear can carry a vertex back into view:
a constant term for the IPD offset, and a w-scaled term covering the lens
asymmetry and the HUD branch's own shear. Being generous costs a few triangles
the GPU then clips; being tight is what caused the popping.

`gfx_dp_set_scissor` already widened the scissor by this same quantity — same
constant, same cause. The clip test was simply missed.

### The winding has to be asked per eye

The backface cross product was computed from `x/w`, i.e. from a centre eye that
is not being rendered. The shear's `−ex` term is depth-dependent, so it does not
cancel out of the cross product, and the two eyes genuinely disagree about
triangles that are near edge-on. A surface exactly edge-on to the centre is
front-facing to one real eye — and was culled in both. The gun sits ~15 cm from
the eye, where the parallax is largest, so it showed up worst there.

The cross product moved into a helper taking that eye's offset, evaluated for one
eye first and for the second only if the first says cull. Front-facing triangles
pay a subtraction; the extra cross lands only on triangles that were about to be
discarded. Multiview gives one vertex stream for both views, so a triangle either
survives for both eyes or neither: it is kept if either eye sees its front. Where
the eyes disagree the other one is looking at a degenerate sliver, so drawing it
there costs nothing.

### Outside VR this is a no-op

The margins stay zero and the winding helper is called with an offset of zero,
which reduces it to the expression that was there before. The flat build is
unaffected by design, not by accident.

### Testing

Quest 3 and PSVR2, single player and Combat Simulator:

- peripheral detail (door panels, wall trim) stays put instead of popping at the
  outer edge of each eye
- the Falcon 2's slide holds at grazing angles
- no change to the flat build

---