### PR TITLE
VR: rumble the support hand when it is gripping a two-handed weapon

### DIFF
--- a/port/src/input.c
+++ b/port/src/input.c
@@ -36,6 +36,7 @@ extern bool vr_leftHasWeapon;
 int vr_button_R_grip = false;
 int vr_button_L_grip = false;
 extern int vr_invert_hands;
+extern bool VrTwoHandsGun(s32 weaponnum);   // bondgun.c: weapon is held with both hands
 int vr_right_gun_fire;
 int vr_left_gun_fire;
 extern bool vr_grip_for_unarmed;
@@ -1071,6 +1072,14 @@ void inputRumble(s32 idx, f32 strength, f32 time) {
             handLeft  = HAND_RIGHT;
         }
 
+        // Support hand for a two-handed grip, same mapping vrBuildGunRotation uses: the
+        // controller that is not the trigger hand. Only meaningful while it is actually
+        // gripping -- an idle off hand is not touching the weapon and should stay quiet.
+        const s32  supportHand    = vr_invert_hands ? 1 : 0;
+        const bool supportOnWeapon =
+                VrTwoHandsGun(g_Vars.currentplayer->gunctrl.weaponnum)
+                && get_button_state(supportHand, "grip");
+
         if (strength > 0.f) {
             if (strength > 1.f) strength = 1.f;
 
@@ -1083,6 +1092,13 @@ void inputRumble(s32 idx, f32 strength, f32 time) {
 
             if (bgunIsFiring(handRight) && vr_right_gun_fire > 0) {
                 trigger_haptic_vibration_c(1, strength, time);
+                // A two-handed weapon lives in a single hand slot, so only the controller
+                // holding it ever pulsed. A gripping support hand is on the same weapon
+                // taking the same recoil, so mirror the pulse onto it -- driven off the
+                // firing hand's own decay, so a burst reads as one weapon and not two.
+                if (supportOnWeapon) {
+                    trigger_haptic_vibration_c(supportHand, strength, time);
+                }
             }
             if (vr_right_gun_fire > 0) {
                 vr_right_gun_fire--;


### PR DESCRIPTION
Firing a two-handed weapon only ever pulsed the trigger-hand controller. The support
hand is wrapped around the same weapon taking the same recoil, so it sat silent
through every burst.

### Why it happened

`inputRumble()` routes haptics per game hand slot: `bgunIsFiring(handRight)` drives
controller 1 and `bgunIsFiring(handLeft)` drives controller 0. A two-handed weapon
occupies a single slot, so the second controller has nothing to key off and never
fired.

### What this does

Mirrors the trigger hand's pulse onto the support hand while it is actually gripping —
`VrTwoHandsGun(weaponnum) && grip held`. An idle off hand is not touching the weapon
and stays quiet, and releasing the grip mid-burst drops it out on the next tick.

The mirrored call sits inside the existing `vr_right_gun_fire` decay block rather than
getting a counter of its own, so both hands run off one timer and a burst reads as a
single weapon held in two hands rather than two rumble sources drifting apart.

### Two details worth noting

Gated on `VrTwoHandsGun`, the two-handed **pose** set, not the narrower
`vrTwoHandAimGun` set. The Slayer is excluded from two-handed *aiming* because the
hands sit too close together to steer with, but its off hand is still on the weapon and
still takes the recoil, so it should rumble.

The support hand is derived as "the controller that is not the trigger hand", following
the `pri`/`off` mapping in `vrBuildGunRotation`. That resolves to physical left in every
shipping configuration, since nothing currently assigns `vr_invert_hands` — it is
written this way so it stays correct if hand inversion is ever wired up.

### Testing

Tested in-headset. Any two-handed weapon (AR34, Shotgun, Dragon): firing one-handed
pulses the right controller only, as before; gripping with the left hand and firing
pulses both; releasing the grip while still holding the trigger drops the left hand out.
The Laser path is untouched, so the #47 hand-swap fix behaves as it did.
```

---