### PR TITLE
VR: fix motion-gesture direction for throwing and melee

### DIFF
--- a/port/vr/vr_input.cpp
+++ b/port/vr/vr_input.cpp
@@ -50,6 +50,18 @@ XrSpaceLocation spaceLocation;
 float vr_ctrl_velocity[2][3]; // [ctrlIndex][x,y,z]
 bool gIsValveIndex = false;
 
+// --- Gesture frame, located against playSpace ---
+// The pose above is located against viewSpace, which is what weapon placement
+// wants. Its velocity is not usable for gestures: a velocity relative to a
+// moving VIEW space needs the runtime to track that space's own velocity, and
+// runtimes that don't just hand back the room-fixed tracking velocity instead.
+// Asking for playSpace explicitly is unambiguous on every runtime, so all swing
+// gestures use these and apply the play -> world transform themselves.
+static XrPosef gCtrlPosePlay[2] = {};
+static XrSpaceVelocity gCachedVelocityPlay[2] = {};
+float vr_ctrl_quat_play[2][4];     // {w,x,y,z}, raw OpenXR basis, play space
+float vr_ctrl_velocity_play[2][3]; // m/s,       raw OpenXR basis, play space
+
 // ===== MANUAL RELOADING =========================
 
 float gVrReloadPullLocalX = 0.0f;
@@ -521,6 +533,21 @@ XrResult update_vr_controllers(XrTime predicted_time) {
 //                vr_log("[VR_DEBUG] hand=%d xrLocateSpace failed: res=%d flags=0x%X pose.isActive=%d",
 //                       hand, (int)res, (unsigned)loc.locationFlags, (int)state.pose.isActive);
                 state.is_active = false;
+            }
+        }
+
+        // Same controller, located against playSpace: the gesture frame.
+        {
+            XrSpaceVelocity velocity = { XR_TYPE_SPACE_VELOCITY };
+            XrSpaceLocation loc = { XR_TYPE_SPACE_LOCATION };
+            loc.next = &velocity;
+
+            XrResult res = xrLocateSpace(gControllerSpace[hand], g_vrState.playSpace, predicted_time, &loc);
+
+            if (XR_SUCCEEDED(res) &&
+                (loc.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT)) {
+                gCtrlPosePlay[hand] = loc.pose;
+                gCachedVelocityPlay[hand] = velocity;
             }
         }
 
@@ -1167,6 +1194,21 @@ void controller_pose() {
             // Reset smoothing if the controller becomes inactive
             sSmoothedInit[i] = false;
             continue;
+        }
+
+        // --- Gesture frame: publish the play-space pose/velocity verbatim ---
+        // Deliberately none of the conditioning applied below. Gesture maths
+        // needs the rotation and the velocity to live in the same basis, and
+        // the mirror/offset/recoil that the weapon pose needs would break that.
+        vr_ctrl_quat_play[i][0] = gCtrlPosePlay[i].orientation.w;
+        vr_ctrl_quat_play[i][1] = gCtrlPosePlay[i].orientation.x;
+        vr_ctrl_quat_play[i][2] = gCtrlPosePlay[i].orientation.y;
+        vr_ctrl_quat_play[i][3] = gCtrlPosePlay[i].orientation.z;
+
+        if (gCachedVelocityPlay[i].velocityFlags & XR_SPACE_VELOCITY_LINEAR_VALID_BIT) {
+            vr_ctrl_velocity_play[i][0] = gCachedVelocityPlay[i].linearVelocity.x;
+            vr_ctrl_velocity_play[i][1] = gCachedVelocityPlay[i].linearVelocity.y;
+            vr_ctrl_velocity_play[i][2] = gCachedVelocityPlay[i].linearVelocity.z;
         }
 
         // --- Raw OpenXR position ---

--- a/port/vr/vr_openxr.cpp
+++ b/port/vr/vr_openxr.cpp
@@ -261,6 +261,16 @@ XrQuaternionf gRawHeadQ = { 0, 0, 0, 1 };
 float g_yawOffsetDegrees = 0.0f;
 float gStandingHeadHeight = 0.0f;
 
+// The recenter alone, as a quaternion: play space -> recentered play space.
+// vr_HMD_rot_Q is this times gRawHeadQ, so anything that starts from a vector
+// already expressed in play space wants THIS, not vr_HMD_rot_Q -- applying the
+// latter would fold the head yaw in a second time.
+XrQuaternionf vr_recenter_rot_Q = { 0, 0, 0, 1 };
+
+// Head linear velocity in play space, raw OpenXR axes, m/s. Subtract it from a
+// controller's play-space velocity to get motion relative to the body.
+float vr_head_velocity_play[3] = { 0.0f, 0.0f, 0.0f };
+
 // ============================================================
 // SMOOTHING HMD — When zoom is enabled
 // ============================================================
@@ -1242,6 +1252,9 @@ static void vr_update_head_tracking(XrTime predictedDisplayTime)
     if (!g_vrState.sessionRunning || g_vrState.session == XR_NULL_HANDLE) return;
 
     XrSpaceLocation headLocation = {XR_TYPE_SPACE_LOCATION};
+    XrSpaceVelocity headVelocity = {XR_TYPE_SPACE_VELOCITY};
+    headLocation.next = &headVelocity;
+
     XrResult result = xrLocateSpace(
             g_vrState.viewSpace, g_vrState.playSpace,
             predictedDisplayTime, &headLocation);
@@ -1266,6 +1279,14 @@ static void vr_update_head_tracking(XrTime predictedDisplayTime)
         XrQuaternionf offsetQ = YawToQuaternion(g_yawOffsetDegrees);
         XrQuaternionf rawQ    = MultiplyQuaternions(offsetQ, gRawHeadQ);
         XrVector3f    rawHead = RotateVectorY(rawPos, g_yawOffsetDegrees);
+
+        vr_recenter_rot_Q = offsetQ;
+
+        if (headVelocity.velocityFlags & XR_SPACE_VELOCITY_LINEAR_VALID_BIT) {
+            vr_head_velocity_play[0] = headVelocity.linearVelocity.x;
+            vr_head_velocity_play[1] = headVelocity.linearVelocity.y;
+            vr_head_velocity_play[2] = headVelocity.linearVelocity.z;
+        }
 
         // --- Grip pressed on either controller ---
         bool gripAny = (vr_button_R_grip != 0) || (vr_button_L_grip != 0);

--- a/port/vr/vr_openxr.h
+++ b/port/vr/vr_openxr.h
@@ -52,11 +52,20 @@ int shaders_build_xr_projection(
 extern XrVector3f gHeadPos;
 extern XrQuaternionf vr_HMD_rot_Q;
 extern XrQuaternionf gRawHeadQ;
+extern XrQuaternionf vr_recenter_rot_Q;
 extern float XrAspect;
 
 extern float gCtrlPos[2][3];
 extern float gCtrlQuat[2][4];
 extern float gCtrlQuatRaw[2][4];
+
+// Gesture frame. Everything above is head-relative and carries the engine's
+// mirrored basis; these are located against playSpace in raw OpenXR axes, with
+// no mirror, no 90deg gun offset, no smoothing and no recoil. Swing gestures
+// need one self-consistent basis, which is what this pair is for.
+extern float vr_ctrl_quat_play[2][4];     // {w,x,y,z}
+extern float vr_ctrl_velocity_play[2][3]; // m/s
+extern float vr_head_velocity_play[3];    // m/s
 
 extern float gStandingHeadHeight;
 extern bool vr_init_done;

--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -85,7 +85,12 @@
 // VR global -----------------------------------------
 extern XrQuaternionf vr_joy_rot_Q;
 extern XrQuaternionf vr_HMD_rot_Q;
+extern XrQuaternionf vr_recenter_rot_Q;
 extern float vr_ctrl_velocity[2][3]; // [ctrlIndex][x,y,z] en m/s
+// Gesture frame: play space, raw OpenXR axes. See vr_openxr.h.
+extern float vr_ctrl_quat_play[2][4];
+extern float vr_ctrl_velocity_play[2][3];
+extern float vr_head_velocity_play[3];
 extern void vr_rotate_vector_by_quaternion(struct coord* v, const XrQuaternionf* q);
 int vr_invert_hands = false;
 bool vr_leftHasWeapon = false;
@@ -2779,6 +2784,12 @@ struct coord vr_throw(s32 handnum) {
 
 
 // 1. Capture the orientation at the time of recording
+//
+// The samples are play-space velocities, so the play -> world rotation is the
+// recenter followed by the stick/snap body yaw. NOT vr_HMD_rot_Q: that already
+// contains the recenter times the raw head rotation, and folding the head yaw
+// into a vector that is not head-relative applies the player's facing twice --
+// which is what used to send every throw off toward the room's forward.
 void vr_record_throw_sample(int ctrlIdx, float vx, float vy, float vz) {
     vr_ThrowSample *s = &gThrowHistory[ctrlIdx][vr_ThrowHistoryIdx[ctrlIdx]];
     s->vx = vx;
@@ -2786,8 +2797,9 @@ void vr_record_throw_sample(int ctrlIdx, float vx, float vy, float vz) {
     s->vz = vz;
     s->vr_magnitude = sqrtf(vx*vx + vy*vy + vz*vz);
 
-    // freeze the head/joystick orientation at THIS exact frame
-    quaternionMul_XR(&vr_joy_rot_Q, &vr_HMD_rot_Q, &s->orientQ);
+    // freeze the body orientation at THIS exact frame, so snap-turning during
+    // the wind-up cannot swing a throw that has already been aimed
+    quaternionMul_XR(&vr_joy_rot_Q, &vr_recenter_rot_Q, &s->orientQ);
 
     s->frame60 = g_Vars.lvframe60;
     vr_ThrowHistoryIdx[ctrlIdx] = (vr_ThrowHistoryIdx[ctrlIdx] + 1) % VR_THROW_HISTORY_MAX;
@@ -2801,15 +2813,15 @@ struct coord vr_throw(s32 handnum) {
                                  : (handnum == HAND_RIGHT ? 0 : 1);
     uint32_t frameNow = g_Vars.lvframe60;
 
-    float bestvx = vr_ctrl_velocity[ctrlIdx][0];
-    float bestvy = vr_ctrl_velocity[ctrlIdx][1];
-    float bestvz = vr_ctrl_velocity[ctrlIdx][2];
+    float bestvx = vr_ctrl_velocity_play[ctrlIdx][0];
+    float bestvy = vr_ctrl_velocity_play[ctrlIdx][1];
+    float bestvz = vr_ctrl_velocity_play[ctrlIdx][2];
     float bestmag = sqrtf(bestvx*bestvx + bestvy*bestvy + bestvz*bestvz);
 
     // Default orientation = the current one, in case
     // the "live" (current) sample wins
     XrQuaternionf bestOrientQ;
-    quaternionMul_XR(&vr_joy_rot_Q, &vr_HMD_rot_Q, &bestOrientQ);
+    quaternionMul_XR(&vr_joy_rot_Q, &vr_recenter_rot_Q, &bestOrientQ);
 
     int count = vr_ThrowHistoryCount[ctrlIdx];
     int cur   = vr_ThrowHistoryIdx[ctrlIdx];
@@ -2837,6 +2849,10 @@ struct coord vr_throw(s32 handnum) {
         throwdir.z = -vz / vrmagnitude;
 
         vr_rotate_vector_by_quaternion(&throwdir, &bestOrientQ);
+        // Negating all three then restoring Y is the 180deg-Y basis flip that
+        // takes an OpenXR direction into game space -- the same convention as
+        // the look vector in vr_player_rot() and the head position in
+        // vr_update_head_tracking(). Leave it alone.
         throwdir.y = -throwdir.y;
 
         float minSpeed = 1.0f, maxSpeed = 1000.0f;
@@ -7761,7 +7777,8 @@ void bgunCreateThrownProjectile(s32 handnum, struct gset* gset)
               gset->weaponnum == WEAPON_TIMEDMINE     ||
               gset->weaponnum == WEAPON_REMOTEMINE ||
               (gset->weaponnum == WEAPON_LAPTOPGUN && gset->weaponfunc == FUNC_SECONDARY)||
-              (gset->weaponnum == WEAPON_DRAGON && gset->weaponfunc == FUNC_SECONDARY))) {
+              (gset->weaponnum == WEAPON_DRAGON && gset->weaponfunc == FUNC_SECONDARY)||
+              (gset->weaponnum == WEAPON_COMBATKNIFE && gset->weaponfunc == FUNC_SECONDARY))) {
         // VR Motion Throwing is enabled: the velocity has already been calculated by vr_throw()
         // in bgunTickIncAttackingThrow, so `velocity` is left unchanged here.
         // do nothing
@@ -15941,8 +15958,9 @@ bool bgunIsUsingSecondaryFunction(void)
 
 
 
-// Rotate a world-space vector v into the local space of quaternion q
-// = multiply by the conjugate (qw, -qx, -qy, -qz)
+// Rotate a vector v into the local space of quaternion q
+// = multiply by the conjugate (qw, -qx, -qy, -qz).
+// v and q must be expressed in the same basis, or the result is meaningless.
 static void worldToLocal(const float q[4], const float v[3], float out[3]) // VR
 {
     float qw =  q[0], qx = -q[1], qy = -q[2], qz = -q[3];
@@ -16067,8 +16085,25 @@ void bgunTickGameplay(bool triggeron) {
             ctrlIndex = (handnum == HAND_RIGHT ? 0 : 1);
         }
 
+        // Swing velocity in the controller's own frame, relative to the body.
+        //
+        // Both inputs are play space in raw OpenXR axes, so the conjugate
+        // rotation actually lands in controller-local space. The old pairing of
+        // gCtrlQuat with vr_ctrl_velocity did not: gCtrlQuat is head-relative
+        // and carries the mirror plus the 90deg gun offset, so the player's head
+        // yaw survived into the result and the gesture only ever fired while
+        // facing the room's forward.
+        //
+        // Subtracting the head keeps this a measure of the hand moving relative
+        // to the player rather than to the room, so walking does not punch.
+        float relVel[3];
         float localVel[3];
-        worldToLocal(gCtrlQuat[ctrlIndex], vr_ctrl_velocity[ctrlIndex], localVel);
+
+        relVel[0] = vr_ctrl_velocity_play[ctrlIndex][0] - vr_head_velocity_play[0];
+        relVel[1] = vr_ctrl_velocity_play[ctrlIndex][1] - vr_head_velocity_play[1];
+        relVel[2] = vr_ctrl_velocity_play[ctrlIndex][2] - vr_head_velocity_play[2];
+
+        worldToLocal(vr_ctrl_quat_play[ctrlIndex], relVel, localVel);
         vr_set_motion_triggered = false;
 
         if(VrMotionThrowing) {
@@ -16082,9 +16117,9 @@ void bgunTickGameplay(bool triggeron) {
 
                 vr_record_throw_sample(
                         ctrlIndex,
-                        vr_ctrl_velocity[ctrlIndex][0],
-                        vr_ctrl_velocity[ctrlIndex][1],
-                        vr_ctrl_velocity[ctrlIndex][2]
+                        vr_ctrl_velocity_play[ctrlIndex][0],
+                        vr_ctrl_velocity_play[ctrlIndex][1],
+                        vr_ctrl_velocity_play[ctrlIndex][2]
                 );
 
             }
@@ -16110,9 +16145,9 @@ void bgunTickGameplay(bool triggeron) {
                 vr_throw_cancelled = true;
                 vr_record_throw_sample(
                         ctrlIndex,
-                        vr_ctrl_velocity[ctrlIndex][0],
-                        vr_ctrl_velocity[ctrlIndex][1],
-                        vr_ctrl_velocity[ctrlIndex][2]
+                        vr_ctrl_velocity_play[ctrlIndex][0],
+                        vr_ctrl_velocity_play[ctrlIndex][1],
+                        vr_ctrl_velocity_play[ctrlIndex][2]
                 );
                 vr_R_knife_sec_anim_run = false;
                 vr_R_func_secondary_knife = false;
@@ -16141,9 +16176,9 @@ void bgunTickGameplay(bool triggeron) {
                 vr_throw_cancelled = true;
                 vr_record_throw_sample(
                         ctrlIndex,
-                        vr_ctrl_velocity[ctrlIndex][0],
-                        vr_ctrl_velocity[ctrlIndex][1],
-                        vr_ctrl_velocity[ctrlIndex][2]
+                        vr_ctrl_velocity_play[ctrlIndex][0],
+                        vr_ctrl_velocity_play[ctrlIndex][1],
+                        vr_ctrl_velocity_play[ctrlIndex][2]
                 );
                 vr_L_knife_sec_anim_run = false;
                 vr_L_func_secondary_knife = false;
@@ -16153,24 +16188,31 @@ void bgunTickGameplay(bool triggeron) {
             }
 
 
-            if (weaponnum == WEAPON_COMBATKNIFE && hand->gset.weaponfunc == FUNC_PRIMARY) {
+            // In controller-local space +Y runs along the barrel and out over
+            // the knuckles: it is the axis that the 90deg X offset applied in
+            // vr_input.cpp maps onto the gun model's forward. So a thrust is +Y
+            // and a slash is whatever is left in the perpendicular XZ plane.
+            // Testing the plane by magnitude keeps the knife's "any of four
+            // directions" behaviour without depending on which way is "up".
+            f32 thrust = localVel[1];
+            f32 slash  = sqrtf(localVel[0] * localVel[0] + localVel[2] * localVel[2]);
 
-                float threshold = 1.0f;
-                bool fwd = (localVel[2] < -threshold);
-                bool left = (localVel[1] > threshold);
-                bool up = (localVel[0] > threshold);
-                bool down = (localVel[0] < -threshold);
-                vr_set_motion_triggered = fwd || left || up || down;
+            if (weaponnum == WEAPON_COMBATKNIFE && hand->gset.weaponfunc == FUNC_PRIMARY) {
+                vr_set_motion_triggered = (thrust > 1.0f) || (slash > 1.0f);
 
             } else if (weaponnum == WEAPON_UNARMED) {
-                vr_set_motion_triggered = (-localVel[0] < -2.0f) || (localVel[2] < -2.0f);
+                // Straight punch, or a hook thrown across the body.
+                vr_set_motion_triggered = (thrust > 1.5f) || (slash > 2.5f);
 
             } else if (weaponnum == WEAPON_FALCON2 ||
                        weaponnum == WEAPON_FALCON2_SCOPE ||
                        weaponnum == WEAPON_FALCON2_SILENCER ||
                        weaponnum == WEAPON_DY357MAGNUM ||
                        weaponnum == WEAPON_DY357LX) {
-                vr_set_motion_triggered = (localVel[2] < -2.0f);
+                // A pistol whip is a swing, not a thrust: the grip travels in an
+                // arc about the wrist, so most of the speed lands perpendicular
+                // to the barrel. Testing thrust alone missed nearly all of them.
+                vr_set_motion_triggered = (thrust > 2.0f) || (slash > 2.0f);
             } else {
                 vr_hand_triggered[i] = false;
                 continue;


### PR DESCRIPTION
## Description

Two bugs that turned out to be the same bug.

- **Thrown items flew toward the play space's forward direction rather than the player's.** Turn 180° physically and throw a grenade, and it flies backwards, away from where you threw it. Affects grenades, all mines, ECM, the Dragon's secondary and thrown knives.
- **Punches and pistol whips only registered while facing the room's forward.** Off-axis, the gesture produced no attack and no sound at all.

### Cause

`vr_ctrl_velocity` is read from `xrLocateSpace(gControllerSpace[hand], viewSpace, ...)`, and both consumers treat it as head-relative. The **pose** from that call is head-relative; the chained **velocity** is not. Reporting a velocity relative to a *moving* VIEW space requires the runtime to track that space's own velocity, and runtimes that don't just return the room-fixed tracking velocity instead. The mismatch is invisible at the call site because the pose beside it behaves as expected.

Each consumer then corrected for a frame the vector had never been in:

- `vr_throw()` rotated it by `vr_joy_rot_Q * vr_HMD_rot_Q`. `vr_HMD_rot_Q` already contains the head yaw (it is the recenter times the raw head rotation), so a room-space velocity got the player's facing applied a second time. At 180° the doubled yaw lands back on the room's forward — exactly the reported symptom.
- The melee gesture conjugated it by `gCtrlQuat`, which *is* head-relative and additionally carries the engine's mirrored basis and the 90° X offset used to build the gun rotation. The player's head yaw therefore survived into what was supposed to be a controller-local vector. Facing forward, the thrust component landed on the tested axis; at 90° it landed on an untested one and nothing fired.

### Fix

Locate the controller a **second time against `playSpace`**, purely for gesture maths, and publish the pose and velocity raw — no mirror, no gun offset, no smoothing, no recoil. Gesture maths needs the rotation and the velocity in one consistent basis, which is what the existing pipeline could not provide. Requesting the frame explicitly is correct whether or not a given runtime honours VIEW as a velocity base space.

The existing view-space path is left completely untouched, so **weapon placement, aiming and recoil are unaffected**. The addition is one extra `xrLocateSpace` per hand per frame, plus an `XrSpaceVelocity` chained onto the head locate that already runs.

With that in place:

- **Throws** rotate by `vr_joy_rot_Q * vr_recenter_rot_Q` — the recenter plus the stick/snap body yaw, with the raw head rotation dropped. The per-sample frozen orientation is kept, so snap-turning mid-wind-up cannot swing a throw that has already been aimed.
- **Melee** evaluates the controller-local velocity minus the head velocity. Subtracting the head keeps this a measure of the hand moving relative to the *player* rather than the room, so walking with your fists up cannot trigger a punch.
- **Thresholds** split into a `thrust` along the grip **+Y** axis — the axis the existing `Rx(+90)` offset maps onto the gun model's forward — and a `slash` magnitude in the perpendicular plane. A pistol whip is a *swing*, not a thrust: the grip travels in an arc about the wrist, so most of the speed lands perpendicular to the barrel and testing thrust alone missed nearly all of them. Testing the plane by magnitude also keeps the knife's "any of four directions" behaviour without depending on which way is "up".

Also fixes an unrelated-looking inconsistency found on the way: `WEAPON_COMBATKNIFE`/`FUNC_SECONDARY` was in `vr_throw()`'s producer list but missing from the list in `bgunCreateThrownProjectile`, so a thrown knife had a VR velocity computed and then immediately overwritten by the stock trajectory solver.

### Testing

Tested in-headset on Quest 3 (Virtual Desktop) against a STAGE play space, over two tuning passes with temporary instrumentation that has since been removed.

- Throws land where thrown at physical facings across the full circle (verified at ~35°, 80°, 144°, 187°, 264°, 317°), and under stick/snap turning, and under both combined.
- Unarmed punches and pistol whips fire at any facing. Hooks register through the `slash` term; the retraction of a punch reads as negative thrust and correctly does not re-fire.
- Knife primary slashes and the secondary throw behave at arbitrary facings.
- No phantom punches while walking with fists raised.

Thresholds were set from logged swing profiles rather than from the value at the instant a threshold was crossed, since the latter is "just over the limit" by construction and says nothing about what a real gesture peaks at.

### Note for the maintainer

`port` at `62b683f7e` does not link on its own — `undefined reference to vr_MpPause` from `mplayer.c`. That is pre-existing on the base branch and unrelated to this change. All four files in this PR compile clean against a bare `port` checkout; only the final link fails, for that reason.
