### PR TITLE
VR: let full-screen effects cover the whole field of view, in both eyes

### DIFF
--- a/port/fast3d/gfx_opengl.cpp
+++ b/port/fast3d/gfx_opengl.cpp
@@ -1538,9 +1538,27 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
     // printf("flushing %d tris\n", buf_vbo_num_tris);
     glBufferData(GL_ARRAY_BUFFER, sizeof(float) * buf_vbo_len, buf_vbo, GL_STREAM_DRAW);
 
-    if (gForceFlatShaderForMenu) {
-        if (gCurEyeOffsetLeftLoc  >= 0) glUniform4f(gCurEyeOffsetLeftLoc,  0.0f, 0.0f, 0.0f, 0.0f);
-        if (gCurEyeOffsetRightLoc >= 0) glUniform4f(gCurEyeOffsetRightLoc, 0.0f, 0.0f, 0.0f, 1000.0f); // hide
+    // A HUD capture draws into a single 2D texture, so it hides the right eye by
+    // pushing that eye's geometry far away. That is correct while capturing --
+    // but these uniforms are per shader program, and the real values are only
+    // uploaded when a program is bound. Setting them here and never putting them
+    // back left every later draw that reused the same program still hiding the
+    // right eye, until some unrelated program switch happened to restore them.
+    // That is how a full-screen effect could come out left-eye-only after a menu
+    // had been opened, and why it looked intermittent. Always write the state
+    // this draw actually wants.
+    if (use_multiview) {
+        if (gForceFlatShaderForMenu) {
+            if (gCurEyeOffsetLeftLoc  >= 0) glUniform4f(gCurEyeOffsetLeftLoc,  0.0f, 0.0f, 0.0f, 0.0f);
+            if (gCurEyeOffsetRightLoc >= 0) glUniform4f(gCurEyeOffsetRightLoc, 0.0f, 0.0f, 0.0f, 1000.0f); // hide
+        } else {
+            if (gCurEyeOffsetLeftLoc >= 0)
+                glUniform4f(gCurEyeOffsetLeftLoc,
+                            s_eye_offsets[0], s_eye_offsets[1], s_eye_offsets[2], s_eye_offsets[3]);
+            if (gCurEyeOffsetRightLoc >= 0)
+                glUniform4f(gCurEyeOffsetRightLoc,
+                            s_eye_offsets[4], s_eye_offsets[5], s_eye_offsets[6], s_eye_offsets[7]);
+        }
     }
 
     glDrawArrays(GL_TRIANGLES, 0, 3 * buf_vbo_num_tris);

--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -87,12 +87,6 @@ void   vr_end_eye_render();
 float* vr_get_eye_proj_mtx(int eye);
 void   vr_get_eye_view_offset(int eye, float* out_tx, float* out_ty, float* out_tz, float *out_tx_HUD);
 bool vr_dl_is_pause_or_menu = false;
-// True only between the menu's begin and end tags, unlike vr_dl_is_pause_or_menu
-// which latches on at the first menu and never clears (the game emits an end tag
-// for it, 0x56520000, that nothing handles). Left that alone deliberately: it
-// drives uIsMenu in the shader, so unlatching it would move the HUD parallax
-// mid-session. This is the flag to use for "menu content is being drawn now".
-static bool vr_dl_menu_scope = false;
 int VrIsPaused = 0;
 static float s_vr_proj_col_major[16] = {};
 extern "C" int vr_get_internal_render_width();
@@ -2312,47 +2306,13 @@ static void gfx_dp_image_rectangle(int32_t tile, int32_t w, int32_t h,
                                    int32_t lrx, int32_t lry, int16_t lrs, int16_t lrt) {
     uint64_t saved_combine_mode = rdp.combine_mode;
 
-    // Widen a full-viewport image rect exactly as gfx_dp_fill_rectangle widens a
-    // full-viewport fill rect, and for the same reason: the headset sees past
-    // the viewport, so the motion blur and the cutscene wash that ride on this
-    // opcode stopped short and left strips down the sides. The difference is
-    // that the source coordinates have to grow by the same proportion, or the
-    // captured frame would be stretched across the bigger rect rather than
-    // extended past it -- the blur has to stay registered with the scene under
-    // it. Sampling then runs off the edge of the capture, so the tile is
-    // clamped below and the edge pixels carry outward.
-    //
-    // Not for menus. The blurred backdrop behind the pause and title menus is
-    // the same opcode over the same captured frame, but it is a deliberate
-    // treatment of that image rather than an overlay on the world, and widening
-    // it garbles the backdrop.
-    bool vr_widened = false;
-
-    if (vr_is_initialized()
-            && !vr_dl_menu_scope
-            && ulx <= 0 && uly <= 0
-            && lrx >= (SCREEN_WIDTH - 1) * 4 && lry >= (SCREEN_HEIGHT - 1) * 4
-            && lrx > ulx && lry > uly) {
-        const int32_t newulx = -2 * 4 * SCREEN_WIDTH;
-        const int32_t newuly = -2 * 4 * SCREEN_HEIGHT;
-        const int32_t newlrx =  3 * 4 * SCREEN_WIDTH;
-        const int32_t newlry =  3 * 4 * SCREEN_HEIGHT;
-
-        const float texelsx = (float)(lrs - uls) / (float)(lrx - ulx);
-        const float texelsy = (float)(lrt - ult) / (float)(lry - uly);
-
-        uls = (int16_t)(uls + (newulx - ulx) * texelsx);
-        lrs = (int16_t)(lrs + (newlrx - lrx) * texelsx);
-        ult = (int16_t)(ult + (newuly - uly) * texelsy);
-        lrt = (int16_t)(lrt + (newlry - lry) * texelsy);
-
-        ulx = newulx;
-        uly = newuly;
-        lrx = newlrx;
-        lry = newlry;
-
-        vr_widened = true;
-    }
+    // The captured frame this opcode draws is sampled over whatever source
+    // region the caller asks for. When that region runs past the edge of the
+    // capture -- which it does when a VR caller deliberately draws the frame
+    // wider than the viewport, to cover a field of view the viewport falls
+    // short of -- wrapping would tile visible copies of the scene into the
+    // margins. Clamp instead, so the frame's edge pixels carry outward.
+    const bool sampling_past_capture = (uls < 0 || ult < 0 || lrs > w || lrt > h);
 
     struct LoadedVertex* ul = &rsp.loaded_vertices[MAX_VERTICES + 0];
     struct LoadedVertex* ll = &rsp.loaded_vertices[MAX_VERTICES + 1];
@@ -2371,10 +2331,8 @@ static void gfx_dp_image_rectangle(int32_t tile, int32_t w, int32_t h,
     rdp.texture_tile[tile].line_size_bytes = w << rdp.texture_tile[tile].siz >> 1;
     rdp.texture_tile[tile].width = w;
     rdp.texture_tile[tile].height = h;
-    // Clamp rather than wrap once widened, so the area past the captured frame
-    // carries its edge pixels outward instead of tiling copies of it.
-    rdp.texture_tile[tile].cms = vr_widened ? G_TX_CLAMP : 0;
-    rdp.texture_tile[tile].cmt = vr_widened ? G_TX_CLAMP : 0;
+    rdp.texture_tile[tile].cms = sampling_past_capture ? G_TX_CLAMP : 0;
+    rdp.texture_tile[tile].cmt = sampling_past_capture ? G_TX_CLAMP : 0;
     rdp.texture_tile[tile].shifts = 0;
     rdp.texture_tile[tile].shiftt = 0;
     auto& loadtex = rdp.loaded_texture[rdp.texture_tile[tile].tmem];
@@ -2516,11 +2474,6 @@ static void gfx_run_dl(Gfx* cmd) {
                 switch (tag_w1) {
                     case 0x56520001: // Menu is open
                         vr_dl_is_pause_or_menu = (tag_w1 & 0xFFFF) != 0; // VR
-                        vr_dl_menu_scope = true;
-                        break;
-
-                    case 0x56520000: // Menu is finished
-                        vr_dl_menu_scope = false;
                         break;
 
                     case VR_MENU_HUD_CAPTURE_BEGIN_L:

--- a/port/vr/vr_openxr.h
+++ b/port/vr/vr_openxr.h
@@ -67,7 +67,6 @@ extern float vr_ctrl_quat_play[2][4];     // {w,x,y,z}
 extern float vr_ctrl_velocity_play[2][3]; // m/s
 extern float vr_head_velocity_play[3];    // m/s
 
-extern float gStandingHeadHeight;
 // A plausible standing head (HMD) height in centimetres, used only until real
 // tracking arrives. Everything that cares about the player's actual height uses
 // the VrPlayerHeight setting.

--- a/src/game/bondview.c
+++ b/src/game/bondview.c
@@ -327,10 +327,27 @@ Gfx *bviewDrawMotionBlur(Gfx *gdl, u32 colour, u32 alpha)
 	}
 #else
     gDPSetFramebufferTextureEXT(gdl++, 0, 0, 0, g_BlurFb);
-    gSPImageRectangleEXT(gdl++,
-                         viewleft << 2, viewtop << 2, viewleft, viewtop,
-                         (viewleft + viewwidth) << 2, (viewtop + viewheight) << 2, viewleft + viewwidth, viewtop + viewheight,
-                         0, videoGetNativeWidth(), videoGetNativeHeight());
+
+    // VR: draw the captured frame a whole view wider than the viewport in every
+    // direction, because the headset sees well past the viewport and a blur that
+    // stops there leaves its edge in your periphery. Source and destination grow
+    // by the same margin in the same units, so the frame stays registered pixel
+    // for pixel with the scene under it rather than being scaled up to fit.
+    // Sampling then runs off the capture, which gfx_dp_image_rectangle answers
+    // by clamping so the edge pixels carry outward.
+    {
+        const s32 marginx = vr_init_done ? viewwidth : 0;
+        const s32 marginy = vr_init_done ? viewheight : 0;
+        const s32 left = viewleft - marginx;
+        const s32 top = viewtop - marginy;
+        const s32 right = viewleft + viewwidth + marginx;
+        const s32 bottom = viewtop + viewheight + marginy;
+
+        gSPImageRectangleEXT(gdl++,
+                             left << 2, top << 2, left, top,
+                             right << 2, bottom << 2, right, bottom,
+                             0, videoGetNativeWidth(), videoGetNativeHeight());
+    }
 #endif
 
     return gdl;

--- a/src/game/game_0b2150.c
+++ b/src/game/game_0b2150.c
@@ -5,6 +5,11 @@
 #include "lib/vi.h"
 #include "data.h"
 #include "types.h"
+#include "gbiex.h"
+
+#ifndef PLATFORM_N64
+#include "../../port/vr/vr_openxr.h"
+#endif
 
 /**
  * With this function stubbed, light glares do not render,
@@ -27,6 +32,28 @@ void func0f0b2150(Gfx **gdlptr, f32 *arg1, f32 *arg2, s32 width, s32 height, s32
 		s32 sp20 = 0;
 		s32 sp1c = 0;
 
+		/**
+		 * The sprite is clipped to the viewport below, because a texture
+		 * rectangle's coordinates are packed into unsigned 12 bit fields and
+		 * cannot address anything outside it.
+		 *
+		 * In VR the viewport only covers the middle of the eye's field of
+		 * view, so that clip leaves a hard rectangular edge sitting in the
+		 * player's periphery. It shows up most on a light glare, which is one
+		 * big soft sprite that is meant to fade out rather than stop dead.
+		 *
+		 * The wide texrect opcode takes signed 24 bit coordinates, so under VR
+		 * the clip box grows by a viewport in every direction instead. That is
+		 * past the edge of the eye, so the sprite runs out on its own texture.
+		 */
+#ifndef PLATFORM_N64
+		const bool wide = vr_init_done;
+#else
+		const bool wide = false;
+#endif
+		const s32 marginx = wide ? viGetWidth() * 4 : 0;
+		const s32 marginy = wide ? viGetHeight() * 4 : 0;
+
 		gDPSetTexturePersp(gdl++, G_TP_NONE);
 
 		xl = (arg1[0] - arg2[0]) * 4.0f;
@@ -41,7 +68,7 @@ void func0f0b2150(Gfx **gdlptr, f32 *arg1, f32 *arg2, s32 width, s32 height, s32
 			yl -= sp1c;
 		}
 
-		if (xh >= 0 && yh >= 0) {
+		if (xh >= -marginx && yh >= -marginy) {
 			if (arg8) {
 				width *= 2;
 				height *= 2;
@@ -49,28 +76,28 @@ void func0f0b2150(Gfx **gdlptr, f32 *arg1, f32 *arg2, s32 width, s32 height, s32
 				t = -(height * 16);
 			}
 
-			if (xl < 0) {
+			if (xl < -marginx) {
 				if (arg5) {
-					t += ((-xl * height) << 5) / (xh - xl);
+					t += (((-marginx - xl) * height) << 5) / (xh - xl);
 				} else {
-					s += ((-xl * width) << 5) / (xh - xl);
+					s += (((-marginx - xl) * width) << 5) / (xh - xl);
 				}
 
-				xl = 0;
+				xl = -marginx;
 			}
 
-			if (yl < 0) {
+			if (yl < -marginy) {
 				if (arg5) {
-					s += ((-yl * width) << 5) / (yh - yl);
+					s += (((-marginy - yl) * width) << 5) / (yh - yl);
 				} else {
-					t += ((-yl * height) << 5) / (yh - yl);
+					t += (((-marginy - yl) * height) << 5) / (yh - yl);
 				}
 
-				yl = 0;
+				yl = -marginy;
 			}
 
-			widthx4 = viGetWidth() * 4;
-			heightx4 = viGetHeight() * 4;
+			widthx4 = viGetWidth() * 4 + marginx;
+			heightx4 = viGetHeight() * 4 + marginy;
 
 			if (widthx4 < xh) {
 				xh = widthx4;
@@ -113,7 +140,11 @@ void func0f0b2150(Gfx **gdlptr, f32 *arg1, f32 *arg2, s32 width, s32 height, s32
 				}
 			}
 
-			if (arg5) {
+			if (wide) {
+#ifndef PLATFORM_N64
+				gSPTextureRectangleWideEXT(gdl++, xl, yl, xh, yh, tile, s, t, dsdx, dtdy, arg5 ? G_ON : G_OFF);
+#endif
+			} else if (arg5) {
 				gSPTextureRectangleFlip(gdl++, xl, yl, xh, yh, tile, s, t, dsdx, dtdy);
 			} else {
 				gSPTextureRectangle(gdl++, xl, yl, xh, yh, tile, s, t, dsdx, dtdy);

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -2602,43 +2602,14 @@ Gfx* playerDrawFade(Gfx* gdl, u32 r, u32 g, u32 b, f32 frac)
         gDPSetRenderMode(gdl++, G_RM_CLD_SURF, G_RM_CLD_SURF2);
         gDPSetCombineMode(gdl++, G_CC_PRIMITIVE, G_CC_PRIMITIVE);
         gDPSetPrimColor(gdl++, 0, 0, r, g, b, (s32)(frac * 255));
+        // Every caller here is a screen-wide effect, so this asks for the whole
+        // viewport. In VR gfx_dp_fill_rectangle widens a full-viewport rect well
+        // past the viewport, because the headset sees past it and an effect that
+        // stops there leaves its edge in your periphery. The cost is that a
+        // split-screen player's fade covers the whole screen rather than their
+        // own viewport.
         gDPFillRectangle(gdl++, viGetViewLeft(), viGetViewTop(),
                          viGetViewLeft() + viGetViewWidth(), viGetViewTop() + viGetViewHeight());
-        gDPPipeSync(gdl++);
-        gDPSetColorDither(gdl++, G_CD_BAYER);
-        gDPSetTexturePersp(gdl++, G_TP_PERSP);
-        gDPSetTextureLOD(gdl++, G_TL_LOD);
-    }
-
-    return gdl;
-}
-
-// playerDrawFade, but covering the whole field of view rather than the
-// viewport, which in a headset falls well short of the edges.
-//
-// 319x239 is not a typo and not the screen size: gfx_dp_fill_rectangle watches
-// for exactly that rect and widens it to roughly twice the screen in every
-// direction, a hack it already carries for widescreen fades. Going through
-// that instead of emitting the wide opcode directly matters -- the wide opcode
-// is two display list words, and however it is being consumed it only ever
-// reaches one eye, while ordinary fill rects (the damage flash, the death
-// wash) reach both.
-static Gfx* playerDrawFadeWide(Gfx* gdl, u32 r, u32 g, u32 b, f32 frac)
-{
-    if (frac > 0) {
-        gDPPipeSync(gdl++);
-        gDPSetCycleType(gdl++, G_CYC_1CYCLE);
-        gDPSetColorDither(gdl++, G_CD_DISABLE);
-        gDPSetTexturePersp(gdl++, G_TP_NONE);
-        gDPSetAlphaCompare(gdl++, G_AC_NONE);
-        gDPSetTextureLOD(gdl++, G_TL_TILE);
-        gDPSetTextureFilter(gdl++, G_TF_BILERP);
-        gDPSetTextureConvert(gdl++, G_TC_FILT);
-        gDPSetTextureLUT(gdl++, G_TT_NONE);
-        gDPSetRenderMode(gdl++, G_RM_CLD_SURF, G_RM_CLD_SURF2);
-        gDPSetCombineMode(gdl++, G_CC_PRIMITIVE, G_CC_PRIMITIVE);
-        gDPSetPrimColor(gdl++, 0, 0, r, g, b, (s32)(frac * 255));
-        gDPFillRectangle(gdl++, 0, 0, 319, 239);
         gDPPipeSync(gdl++);
         gDPSetColorDither(gdl++, G_CD_BAYER);
         gDPSetTexturePersp(gdl++, G_TP_PERSP);
@@ -5434,7 +5405,7 @@ Gfx* playerRenderHud(Gfx* gdl)
             f32 headclip = vr_get_head_clip_frac();
 
             if (headclip > 0.0f) {
-                gdl = playerDrawFadeWide(gdl, 0, 0, 0, headclip);
+                gdl = playerDrawFade(gdl, 0, 0, 0, headclip);
             }
         }
 


### PR DESCRIPTION
Follow-up to #70, which fixed most of this but left two holes and opened one regression. All three are the same class of bug, so they are together here.

### A full-screen effect could appear in one eye only

gfx_opengl_draw_triangles hides the right eye while a HUD capture is active, by pushing that eye's geometry far away. A capture draws into a single 2D texture, so that is correct -- but uEyeOffsetLeft/Right are per shader program, and the real values are uploaded only when a program is bound. Setting them here and never restoring them left every later draw that reused the same program still hiding the right eye, until some unrelated program switch happened to put the real values back.

The result was a full-screen wash showing in the left eye only, appearing intermittently once a menu had been opened, depending on whether a program switch fell between the capture and the effect. It also explains why moving such a draw earlier in the frame used to make the problem go away: earlier meant before anything had clobbered the uniforms.

Each draw now writes the eye offsets it actually wants. That is two glUniform4f per triangle batch, not per triangle.

### Light glares stopped at a hard edge

Light glares, suns and lens flares all go through func0f0b2150, which clips the sprite to the viewport because a texture rectangle's coordinates are packed into unsigned 12 bit fields and cannot address anything outside it. In VR the viewport covers only the middle of the eye, so the clip left a rectangular edge in the player's periphery -- most obvious on a bright light glare, which is one big soft sprite meant to fade out rather than stop dead.

gSPTextureRectangleWideEXT takes signed 24 bit coordinates, so under VR the clip box grows by a viewport in every direction and the sprite goes out through that opcode instead. The s/t compensation generalises to the wider box, so a sprite that still gets clipped stays aligned. With the margin at zero the arithmetic is identical to before, so non-VR builds are untouched.

It stays a box rather than no clip at all because gfx_dp_texture_rectangle computes the texture span through an int16_t.

### The image rect widening in #70 was too broad

It fired on any full-viewport image rect, including draws it was never meant to touch. The widening now lives at the one call site that needs it, bviewDrawMotionBlur, which grows its own source and destination by equal margins in the same units so the captured frame stays registered with the scene. gfx_dp_image_rectangle keeps only the part that has to be central -- clamping the tile when the source region runs past the captured frame -- which it now detects from the coordinates rather than from having done the widening itself. Menus need no special case any more, since nothing widens generically, so vr_dl_menu_scope goes with it.

### Two leftovers from merged PRs

playerDrawFadeWide forced the old fixed-bounds widening by passing a 319x239 rect, back when that was the only rect gfx_dp_fill_rectangle would widen. It widens any full-viewport rect now, so the comfort fade goes through plain playerDrawFade like every other screen-wide effect. And gStandingHeadHeight is declared in vr_openxr.h but defined and used nowhere.