### PR TITLE
Fix issue #43: prevent weapon and hand disappearance

### DIFF
--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -576,6 +576,10 @@ static bool isHandIndex(s32 mtxindex) {
 
 void vrBuildMtxPartsList(struct hand *hand, struct modeldef *modeldef, bool filterHands) {
     s_gunMovableCount = 0;
+    // VR: reset the hidden-part state whenever the movable-part list is rebuilt.
+    // Otherwise stale "hidden" flags from a previous weapon/reload/throw persist
+    // into the new list, making the gun and hands disappear (issue #43).
+    for (s32 i = 0; i < VR_MAX_GUN_PARTS; i++) s_vrPartHidden[i] = false;
     if (!modeldef) return;
 
     struct modelnode *node = modeldef->rootnode;
@@ -11457,9 +11461,13 @@ void bgun0f0a5550(s32 handnum) {
                 VrTwoHandGrip = get_button_state(0, "grip");
             }
 
-            if (weaponnum == WEAPON_REMOTEMINE || weaponnum == WEAPON_LASER
-                || (VrTwoHandGrip && VrTwoHandsGun(g_Vars.currentplayer->gunctrl.weaponnum))) {
+            if (weaponnum == WEAPON_REMOTEMINE || weaponnum == WEAPON_LASER) {
                 // Nothing
+            } else if (VrTwoHandGrip && VrTwoHandsGun(g_Vars.currentplayer->gunctrl.weaponnum)) {
+                // VR: two-handed grip - keep the gun visible even if the copy-weapon
+                // path left parts hidden (e.g. after a reload or weapon switch, issue #43).
+                for (s32 i = 0; i < s_gunMovableCount; i++) s_vrPartHidden[i] = false;
+                vrHideGunParts(hand->gunmodel.matrices);
             } else {
                 if (hand->state != HANDSTATE_RELOAD) {
                     vrHideOnly(LeftHandMtx);


### PR DESCRIPTION
﻿## Summary
Fixes #43, where the equipped weapon and hands could become permanently invisible after weapon changes, reload-related hiding, or selecting the ECM weapon in the standalone Quest 3 VR build.
## Root cause
The VR weapon renderer stores per-part visibility in the persistent `s_vrPartHidden` array. `vrBuildMtxPartsList()` rebuilt the matrix-index list but left those flags from the previous weapon or render mode intact. A prior `vrHideAllExcept(HideAll)` could therefore hide every part of the newly selected weapon.
The main render path also skipped its visibility reset while a supported two-handed weapon was actively gripped. The copy-weapon render path can intentionally hide all of its parts in that state, so the next main weapon frame could inherit stale hidden flags and render the weapon and hands invisible.
## Changes
- Reset every `s_vrPartHidden` entry whenever `vrBuildMtxPartsList()` rebuilds the movable-part list, before handling a new model definition.
- In `bgun0f0a5550()`, handle the two-handed grip as an explicit visibility case: clear stale hidden flags and apply the normal gun-part matrix update so the primary weapon remains visible.
- Preserve the existing hiding behavior for remote mines, the laser, reload animations, and copy-weapon/off-hand rendering.
## Expected behavior
Weapon switches now start from a clean per-part visibility state. Two-handed weapons such as the K7 Avenger should remain visible after switching from the Falcon 2 or after reload/copy-weapon rendering, while reload-specific parts can still be hidden or shown by the existing mode logic.
## Validation
- `android\\gradlew.bat assembleDebug` - passed; produced `android/app/build/outputs/apk/debug/app-debug.apk`.
- `cmake --build build-pc-mingw --target pd -j 4` - attempted, but the existing MinGW build configuration failed before completing compilation with `cc1plus.exe: error: too many filenames given` and an invalid temporary response-file argument. No source diagnostic was reported for this change.
- `installDebug` / device testing - not run successfully because no Android device or emulator was connected.
## Hardware test still needed
Install the debug APK on a Meta Quest 3 and exercise Falcon 2 -> K7 Avenger, the ECM weapon, reload transitions, and repeated weapon switching while gripping and releasing two-handed weapons. Confirm that the weapon, hands, firing, melee, and laser sight remain synchronized and visible.
